### PR TITLE
Fix: package.json files prop doesn't contain types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "index.js",
     "evaluator.js",
     "serialize.js",
+    "*.d.ts",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
package.json files prop filters on install and publish

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files