### PR TITLE
Implement type checker

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -42,6 +42,27 @@ export class EvaluationError extends Error {
   }
 }
 
+export class TypeError extends Error {
+  #wasConstructedWithAst = false
+  constructor(message, node, cause) {
+    super(message, {cause})
+    this.name = 'TypeError'
+
+    const pos = node && (node.input ? node : nodePositionCache.get(node))
+    if (pos) {
+      this.#wasConstructedWithAst = true
+      this.message = formatErrorWithHighlight(this.message, pos)
+    }
+  }
+
+  withAst(node) {
+    if (this.#wasConstructedWithAst) return this
+    const pos = node && (node.input ? node : nodePositionCache.get(node))
+    if (pos) this.message = formatErrorWithHighlight(this.message, pos)
+    return this
+  }
+}
+
 function formatErrorWithHighlight(message, position) {
   if (position?.pos === undefined) return message
   const pos = position.pos

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -1,4 +1,3 @@
-import Parser from './parser.js'
 import {
   allFunctions,
   createFunctionRegistry,
@@ -8,8 +7,10 @@ import {
   Duration,
   UnsignedInt
 } from './functions.js'
-import {EvaluationError, ParseError} from './errors.js'
+import {EvaluationError, ParseError, TypeError} from './errors.js'
 import {OVERLOADS, createOverloadRegistry} from './overloads.js'
+import {TypeChecker} from './type-checker.js'
+import {Parser} from './parser.js'
 
 function firstNode(a, b) {
   return Array.isArray(a) ? a : b
@@ -205,8 +206,8 @@ function unaryOverload(ast, s) {
   const left = s.eval(ast[1])
   const leftType = s.debugType(left)
   const overload = s.overloads[ast[0]]?.[leftType]
-  if (!overload) throw new EvaluationError(`no such overload: ${ast[0][0]}${leftType}`, ast)
-  return overload(left)
+  if (overload) return overload.handler(left)
+  throw new EvaluationError(`no such overload: ${ast[0][0]}${leftType}`, ast)
 }
 
 const kAstCache = Symbol('astCache')
@@ -246,8 +247,8 @@ function binaryOverload(ast, s) {
   const rightType = s.debugType(right)
   const overload =
     s.overloads[ast[0]][leftType]?.[rightType] || getOverload(s, ast, leftType, rightType)
-  if (overload) return overload(left, right, ast, s)
 
+  if (overload) return overload.handler(left, right, ast, s)
   throw new EvaluationError(`no such overload: ${leftType} ${ast[0]} ${rightType}`, ast)
 }
 
@@ -363,7 +364,9 @@ class Environment {
   #overloads
   #functions
   #legacyFunctions
+
   #evaluator
+  #typeChecker
 
   constructor(opts) {
     if (opts?.supportLegacyFunctions) {
@@ -395,13 +398,17 @@ class Environment {
       return this
     }
 
-    this.#evaluator = new Evaluator({
+    const childOpts = {
       environment: this,
       variables: this.#variables,
       overloads: this.#overloads,
       functions: this.#functions,
+      types: this.#types,
       constructorToType: this.#constructorToType
-    })
+    }
+
+    this.#evaluator = new Evaluator(childOpts)
+    this.#typeChecker = new TypeChecker(childOpts)
 
     Object.freeze(this)
   }
@@ -448,8 +455,25 @@ class Environment {
   parse(expression) {
     const ast = new Parser(expression).parse()
     const evaluateParsed = this.#evaluateAST.bind(this, ast)
+    evaluateParsed.check = this.#checkAST.bind(this, ast)
     evaluateParsed.ast = ast
     return evaluateParsed
+  }
+
+  check(expression) {
+    try {
+      return {valid: true, type: this.#typeChecker.check(new Parser(expression).parse())}
+    } catch (e) {
+      return {valid: false, error: e}
+    }
+  }
+
+  #checkAST(ast) {
+    try {
+      return {valid: true, type: this.#typeChecker.check(ast)}
+    } catch (e) {
+      return {valid: false, error: e}
+    }
   }
 
   #evaluateWithLegacyFunctions(expression, context, legacyFunctions) {
@@ -674,7 +698,7 @@ export function evaluate(expression, context, functions) {
   return globalEnvironment.evaluate(expression, context, functions)
 }
 
-export {ParseError, EvaluationError, Duration, UnsignedInt, Environment}
+export {ParseError, EvaluationError, TypeError, Duration, UnsignedInt, Environment}
 
 export default {
   parse,
@@ -682,6 +706,7 @@ export default {
   Environment,
   ParseError,
   EvaluationError,
+  TypeError,
   Duration,
   UnsignedInt
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import {parse, evaluate, Environment, ParseError, EvaluationError} from './evaluator.js'
+import {parse, evaluate, Environment, ParseError, EvaluationError, TypeError} from './evaluator.js'
 import {serialize} from './serialize.js'
-export {parse, evaluate, Environment, ParseError, EvaluationError, serialize}
-export default {parse, evaluate, Environment, ParseError, EvaluationError, serialize}
+export {parse, evaluate, Environment, ParseError, EvaluationError, TypeError, serialize}
+export default {parse, evaluate, Environment, ParseError, EvaluationError, TypeError, serialize}

--- a/lib/overloads.js
+++ b/lib/overloads.js
@@ -14,33 +14,66 @@ export function createOverloadRegistry(localOverloads, customTypes) {
   return {registerOperatorOverload, unaryOverload, binaryOverload}
 
   function registerOperatorOverload(string, handler) {
-    const unaryParts = string.match(/^([-!])([\w.<>]+)$/)
-    if (unaryParts) return unaryOverload(unaryParts[1], unaryParts[2], handler)
+    // Parse with optional return type: "Vector + Vector: Vector" or "Vector + Vector"
+    const unaryParts = string.match(/^([-!])([\w.<>]+)(?::\s*([\w.<>]+))?$/)
+    if (unaryParts) {
+      const [, op, operandType, returnType] = unaryParts
+      return unaryOverload(op, operandType, handler, returnType || operandType)
+    }
 
-    const parts = string.match(/^([\w.<>]+) ([-+*%/]|==|!=|<|<=|>|>=|in) ([\w.<>]+)$/)
+    const parts = string.match(
+      /^([\w.<>]+) ([-+*%/]|==|!=|<|<=|>|>=|in) ([\w.<>]+)(?::\s*([\w.<>]+))?$/
+    )
     if (!parts) throw new Error(`Operator overload invalid: ${string}`)
-    return binaryOverload(parts[1], parts[2], parts[3], handler)
+    const [, leftType, op, rightType, returnType] = parts
+    return binaryOverload(leftType, op, rightType, handler, returnType)
   }
 
-  function unaryOverload(_op, type, handler) {
+  function unaryOverload(_op, type, handler, returnType) {
     if (!hasType(customTypes, type)) {
       throw new Error(`Invalid type '${type}' in '${_op}${type}'`)
     }
 
+    if (returnType && !hasType(customTypes, returnType)) {
+      throw new Error(`Invalid return type '${returnType}' in '${_op}${type}: ${returnType}'`)
+    }
+
     const op = `${_op}_`
     localOverloads[op] ??= {}
-    if (localOverloads[op][type])
-      throw new Error(`Operator overload already registered: ${_op}${type}`)
-    localOverloads[op][type] = handler
+    if (!localOverloads[op][type]) localOverloads[op][type] = {handler, returnType}
+    else throw new Error(`Operator overload already registered: ${_op}${type}`)
   }
 
-  function binaryOverload(leftType, op, rightType, handler) {
+  function binaryOverload(leftType, op, rightType, handler, returnType) {
     if (!hasType(customTypes, leftType)) {
       throw new Error(`Invalid left type '${leftType}' in '${leftType} ${op} ${rightType}'`)
     }
 
     if (!hasType(customTypes, rightType)) {
       throw new Error(`Invalid right type '${rightType}' in '${leftType} ${op} ${rightType}'`)
+    }
+
+    if (returnType && !hasType(customTypes, returnType)) {
+      throw new Error(
+        `Invalid return type '${returnType}' in '${leftType} ${op} ${rightType}: ${returnType}'`
+      )
+    }
+
+    if (
+      op === '<' ||
+      op === '<=' ||
+      op === '>' ||
+      op === '>=' ||
+      op === '==' ||
+      op === '!=' ||
+      op === 'in'
+    ) {
+      returnType ??= 'bool'
+      if (returnType !== 'bool') {
+        throw new Error(`Comparison operator '${op}' must return 'bool', got '${returnType}'`)
+      }
+    } else {
+      returnType ??= leftType
     }
 
     localOverloads[op] ??= {}
@@ -61,14 +94,14 @@ export function createOverloadRegistry(localOverloads, customTypes) {
       if (rightNeqObj[leftType])
         throw new Error(`Operator overload already registered: ${rightType} != ${leftType}`)
 
-      leftEqObj[rightType] = handler
-      rightEqObj[leftType] = (a, b, ast) => handler(b, a, ast)
+      leftEqObj[rightType] = {handler, returnType}
+      rightEqObj[leftType] = {handler: (a, b, ast) => handler(b, a, ast), returnType}
 
-      leftNeqObj[rightType] = (a, b, ast) => !handler(a, b, ast)
-      rightNeqObj[leftType] = (a, b, ast) => !handler(b, a, ast)
+      leftNeqObj[rightType] = {handler: (a, b, ast) => !handler(a, b, ast), returnType}
+      rightNeqObj[leftType] = {handler: (a, b, ast) => !handler(b, a, ast), returnType}
     } else {
       const leftObj = (localOverloads[op][leftType] ??= {})
-      if (leftObj[rightType] === undefined) leftObj[rightType] = handler
+      if (leftObj[rightType] === undefined) leftObj[rightType] = {handler, returnType}
       else throw new Error(`Operator overload already registered: ${leftType} ${op} ${rightType}`)
     }
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -429,7 +429,7 @@ class Lexer {
   }
 }
 
-export default class Parser {
+export class Parser {
   constructor(input) {
     this.lexer = new Lexer(input)
     this.currentToken = this.lexer.nextToken()

--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -1,0 +1,277 @@
+import {TypeError} from './errors.js'
+import {Duration, UnsignedInt} from './functions.js'
+
+/**
+ * TypeChecker performs static type analysis on CEL expressions
+ * without executing them. It validates:
+ * - Variable existence and types
+ * - Function signatures and overloads
+ * - Operator compatibility using the actual overload registry
+ * - Property and index access validity
+ */
+export class TypeChecker {
+  constructor({environment, variables, functions, types, overloads}) {
+    this.environment = environment
+    this.variables = variables
+    this.functions = functions
+    this.types = types
+    this.overloads = overloads
+  }
+
+  /**
+   * Check an expression and return its inferred type
+   * @param {Array|any} ast - The AST node to check
+   * @returns {string} The inferred type name
+   * @throws {TypeError} If type checking fails
+   */
+  check(ast) {
+    if (!Array.isArray(ast)) return this.inferLiteralType(ast)
+
+    switch (ast[0]) {
+      case 'id':
+        return this.checkVariable(ast)
+      case '.':
+      case '[]':
+        return this.checkAccess(ast)
+      case 'call':
+        return this.checkCall(ast)
+      case 'rcall':
+        return this.checkMethodCall(ast)
+      case 'list':
+        return this.checkList(ast)
+      case 'map':
+        return this.checkMap(ast)
+      case '?:':
+        return this.checkTernary(ast)
+      case '||':
+      case '&&':
+        return this.checkLogicalOp(ast)
+      case '!_':
+      case '-_':
+        return this.checkUnaryOperator(ast)
+      case '==':
+      case '!=':
+      case '<':
+      case '<=':
+      case '>':
+      case '>=':
+      case '+':
+      case '-':
+      case '*':
+      case '/':
+      case '%':
+      case 'in':
+        return this.checkBinaryOperator(ast)
+      default:
+        throw new TypeError(`Unknown operation: ${ast[0]}`, ast)
+    }
+  }
+
+  inferLiteralType(value) {
+    switch (typeof value) {
+      case 'string':
+        return 'string'
+      case 'bigint':
+        return 'int'
+      case 'number':
+        return 'double'
+      case 'boolean':
+        return 'bool'
+      case 'object':
+        if (value === null) return 'null'
+        if (value instanceof Uint8Array) return 'bytes'
+        if (value instanceof Date) return 'google.protobuf.Timestamp'
+        if (value instanceof Duration) return 'google.protobuf.Duration'
+        if (value instanceof UnsignedInt) return 'uint'
+        throw new TypeError(`Unexpected object in AST: ${value.constructor?.name || value}`)
+      default:
+        return 'dyn'
+    }
+  }
+
+  checkVariable(ast) {
+    const varName = ast[1]
+    const varType = this.variables.get(varName)
+    if (varType !== undefined) return varType
+    throw new TypeError(`Unknown variable: ${varName}`, ast)
+  }
+
+  checkAccess(ast) {
+    const leftType = this.check(ast[1])
+
+    if (leftType === 'dyn') return 'dyn'
+
+    if (ast[0] === '.') {
+      // Property access is allowed on maps, lists (arrays), and custom types
+      // At runtime, . is converted to [] and handled by objectGet
+      if (leftType === 'map' || leftType === 'list' || this.types.has(leftType)) {
+        return 'dyn'
+      }
+      throw new TypeError(`Cannot access property on type '${leftType}'`, ast)
+    }
+
+    if (ast[0] === '[]') {
+      const indexType = this.check(ast[2])
+
+      if (leftType === 'list') {
+        if (indexType !== 'int' && indexType !== 'uint' && indexType !== 'dyn') {
+          throw new TypeError(`List index must be int or uint, got '${indexType}'`, ast)
+        }
+        return 'dyn'
+      }
+
+      if (leftType === 'map') return 'dyn'
+
+      // No other types support [] indexing
+      throw new TypeError(`Cannot index type '${leftType}'`, ast)
+    }
+
+    return 'dyn'
+  }
+
+  checkCall(ast) {
+    const functionName = ast[1]
+    const fn = this.functions.standalone[functionName]
+    if (!fn) throw new TypeError(`Function not found: '${functionName}'`, ast)
+
+    if (!fn.macro) {
+      const args = ast[2]
+      const argTypes = args.map((arg) => this.check(arg))
+
+      let current = fn
+      for (const argType of argTypes) {
+        if (!current) {
+          throw new TypeError(
+            `No matching overload for '${functionName}(${argTypes.join(', ')})'`,
+            ast
+          )
+        }
+        current = current[argType] || current['dyn']
+      }
+
+      if (current?.handler) return current.returnType || 'dyn'
+      throw new TypeError(`No matching overload for '${functionName}(${argTypes.join(', ')})'`, ast)
+    }
+
+    return this.functions.returnTypes[functionName] || 'dyn'
+  }
+
+  checkMethodCall(ast) {
+    const methodName = ast[1]
+    const receiverType = this.check(ast[2])
+    if (receiverType === 'dyn') return 'dyn'
+
+    const fn = this.functions[receiverType]?.[methodName]
+    if (!fn) {
+      throw new TypeError(`Method not found: '${methodName}' for type '${receiverType}'`, ast)
+    }
+
+    if (!fn.macro) {
+      const args = ast[3]
+      const argTypes = args.map((arg) => this.check(arg))
+
+      let current = fn
+      for (const argType of argTypes) {
+        if (!current) {
+          throw new TypeError(
+            `No matching overload for '${receiverType}.${methodName}(${argTypes.join(', ')})'`,
+            ast
+          )
+        }
+        current = current[argType] || current['dyn']
+      }
+
+      if (!current || !current.handler) {
+        throw new TypeError(
+          `No matching overload for '${receiverType}.${methodName}(${argTypes.join(', ')})'`,
+          ast
+        )
+      }
+
+      return current.returnType || 'dyn'
+    }
+
+    return this.functions.returnTypes[methodName] || 'dyn'
+  }
+
+  checkList(ast) {
+    const elements = ast[1]
+    for (let i = 0; i < elements.length; i++) this.check(elements[i])
+    return 'list'
+  }
+
+  checkMap(ast) {
+    const entries = ast[1]
+    for (let i = 0; i < entries.length; i++) {
+      const [key, value] = entries[i]
+      this.check(key)
+      this.check(value)
+    }
+    return 'map'
+  }
+
+  checkTernary(ast) {
+    const condType = this.check(ast[1])
+    if (condType !== 'bool' && condType !== 'dyn') {
+      throw new TypeError(`Ternary condition must be bool, got '${condType}'`, ast)
+    }
+
+    const trueType = this.check(ast[2])
+    const falseType = this.check(ast[3])
+    if (trueType === falseType) return trueType
+    return 'dyn'
+  }
+
+  checkLogicalOp(ast) {
+    const leftType = this.check(ast[1])
+    const rightType = this.check(ast[2])
+
+    if (leftType !== 'bool' && leftType !== 'dyn') {
+      throw new TypeError(`Logical operator requires bool operands, got '${leftType}'`, ast)
+    }
+    if (rightType !== 'bool' && rightType !== 'dyn') {
+      throw new TypeError(`Logical operator requires bool operands, got '${rightType}'`, ast)
+    }
+
+    return 'bool'
+  }
+
+  checkUnaryOperator(ast) {
+    const op = ast[0]
+    const operandType = this.check(ast[1])
+    if (operandType === 'dyn') return op === '!_' ? 'bool' : 'dyn'
+
+    const overload = this.overloads[op]?.[operandType]
+    if (overload) return overload.returnType || operandType
+    throw new TypeError(`Unary operator '${op[0]}' not defined for type '${operandType}'`, ast)
+  }
+
+  checkBinaryOperator(ast) {
+    const leftType = this.check(ast[1])
+    const rightType = this.check(ast[2])
+    const op = ast[0]
+
+    if (leftType === 'dyn' || rightType === 'dyn') {
+      if (
+        op === '<' ||
+        op === '<=' ||
+        op === '>' ||
+        op === '>=' ||
+        op === '==' ||
+        op === '!=' ||
+        op === 'in'
+      ) {
+        return 'bool'
+      }
+      return 'dyn'
+    }
+
+    const overload = this.overloads[op]?.[leftType]?.[rightType]
+    if (overload) return overload.returnType
+
+    throw new TypeError(
+      `Operator '${op}' not defined for types '${leftType}' and '${rightType}'`,
+      ast
+    )
+  }
+}

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -215,6 +215,40 @@ test('Environment - parse() method for AST reuse', () => {
   assert.strictEqual(result2, 11n)
 })
 
+test('Environment - parse() returns function with check method', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'int')
+
+  const parsed = env.parse('x + y')
+
+  // Check method should be available
+  assert.strictEqual(typeof parsed.check, 'function')
+
+  // Check should return type information
+  const checkResult = parsed.check()
+  assert.strictEqual(checkResult.valid, true)
+  assert.strictEqual(checkResult.type, 'int')
+
+  // Should still be able to evaluate
+  const evalResult = parsed({x: 5n, y: 3n})
+  assert.strictEqual(evalResult, 8n)
+})
+
+test('Environment - parse() check detects type errors', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'string')
+
+  const parsed = env.parse('x + y')
+
+  // Type error should be caught by check
+  const checkResult = parsed.check()
+  assert.strictEqual(checkResult.valid, false)
+  assert.ok(checkResult.error)
+  assert.ok(checkResult.error.message.includes('not defined'))
+})
+
 test('Environment - duplicate variable registration throws', () => {
   const env = new Environment().registerVariable('x', 'int')
 

--- a/test/operator-return-types.test.js
+++ b/test/operator-return-types.test.js
@@ -1,0 +1,244 @@
+import {test} from 'node:test'
+import assert from 'node:assert'
+import {Environment} from '../lib/evaluator.js'
+
+test('Operator return types - explicit return type declaration', () => {
+  class Vector {
+    constructor(x, y) {
+      this.x = x
+      this.y = y
+    }
+    add(other) {
+      return new Vector(this.x + other.x, this.y + other.y)
+    }
+    dot(other) {
+      return this.x * other.x + this.y * other.y
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Vector', Vector)
+    .registerVariable('v1', 'Vector')
+    .registerVariable('v2', 'Vector')
+    .registerOperator('Vector + Vector: Vector', (a, b) => a.add(b))
+    .registerOperator('Vector * Vector: double', (a, b) => a.dot(b))
+
+  // Vector + Vector should return Vector
+  const addResult = env.check('v1 + v2')
+  assert.strictEqual(addResult.valid, true)
+  assert.strictEqual(addResult.type, 'Vector')
+
+  // Vector * Vector (dot product) should return double
+  const dotResult = env.check('v1 * v2')
+  assert.strictEqual(dotResult.valid, true)
+  assert.strictEqual(dotResult.type, 'double')
+
+  // Verify it works at runtime
+  const v1 = new Vector(3, 4)
+  const v2 = new Vector(1, 2)
+  const sum = env.evaluate('v1 + v2', {v1, v2})
+  assert.strictEqual(sum.x, 4)
+  assert.strictEqual(sum.y, 6)
+
+  const dot = env.evaluate('v1 * v2', {v1, v2})
+  assert.strictEqual(dot, 11) // 3*1 + 4*2
+})
+
+test('Operator return types - default to left operand type', () => {
+  class Point {
+    constructor(x, y) {
+      this.x = x
+      this.y = y
+    }
+    scale(factor) {
+      return new Point(this.x * factor, this.y * factor)
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Point', Point)
+    .registerVariable('p', 'Point')
+    .registerVariable('scale', 'double')
+    .registerOperator('Point * double', (p, s) => p.scale(s))
+
+  // Point * double should default to Point (left operand type)
+  const result = env.check('p * scale')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'Point')
+
+  // Verify at runtime
+  const p = new Point(2, 3)
+  const scaled = env.evaluate('p * scale', {p, scale: 2.5})
+  assert.strictEqual(scaled.x, 5)
+  assert.strictEqual(scaled.y, 7.5)
+})
+
+test('Operator return types - unary operators', () => {
+  class Complex {
+    constructor(real, imag) {
+      this.real = real
+      this.imag = imag
+    }
+    negate() {
+      return new Complex(-this.real, -this.imag)
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Complex', Complex)
+    .registerVariable('c', 'Complex')
+    .registerOperator('-Complex: Complex', (c) => c.negate())
+
+  // -Complex should return Complex
+  const result = env.check('-c')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'Complex')
+
+  // Verify at runtime
+  const c = new Complex(3, 4)
+  const negated = env.evaluate('-c', {c})
+  assert.strictEqual(negated.real, -3)
+  assert.strictEqual(negated.imag, -4)
+})
+
+test('Operator return types - comparison operators always return bool', () => {
+  class Money {
+    constructor(amount) {
+      this.amount = amount
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Money', Money)
+    .registerVariable('m1', 'Money')
+    .registerVariable('m2', 'Money')
+    .registerOperator('Money == Money', (a, b) => a.amount === b.amount)
+    .registerOperator('Money < Money', (a, b) => a.amount < b.amount)
+
+  // Comparison operators should return bool
+  assert.strictEqual(env.check('m1 == m2').type, 'bool')
+  assert.strictEqual(env.check('m1 != m2').type, 'bool')
+  assert.strictEqual(env.check('m1 < m2').type, 'bool')
+
+  // Verify at runtime
+  const m1 = new Money(100)
+  const m2 = new Money(200)
+  assert.strictEqual(env.evaluate('m1 < m2', {m1, m2}), true)
+  assert.strictEqual(env.evaluate('m1 == m2', {m1, m2}), false)
+  assert.strictEqual(env.evaluate('m1 != m2', {m1, m2}), true)
+})
+
+test('Operator return types - mixed with built-in operators', () => {
+  class Counter {
+    constructor(value) {
+      this.value = value
+    }
+    increment() {
+      return new Counter(this.value + 1)
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Counter', Counter)
+    .registerVariable('c', 'Counter')
+    .registerVariable('n', 'int')
+    .registerOperator('Counter + Counter: Counter', (a, b) => new Counter(a.value + b.value))
+
+  // Counter + Counter returns Counter
+  const result1 = env.check('c + c')
+  assert.strictEqual(result1.valid, true)
+  assert.strictEqual(result1.type, 'Counter')
+
+  // int + int still returns int (built-in)
+  const result2 = env.check('n + n')
+  assert.strictEqual(result2.valid, true)
+  assert.strictEqual(result2.type, 'int')
+
+  // Verify at runtime
+  const c = new Counter(5)
+  const sum = env.evaluate('c + c', {c})
+  assert.strictEqual(sum.value, 10)
+})
+
+test('Operator return types - invalid return type rejected', () => {
+  class Foo {}
+
+  const env = new Environment().registerType('Foo', Foo)
+
+  // Should throw when registering operator with invalid return type
+  assert.throws(
+    () => {
+      env.registerOperator('Foo + Foo: InvalidType', () => {})
+    },
+    /Invalid return type 'InvalidType'/
+  )
+
+  // Should throw when trying to specify non-bool return type for comparison operators
+  assert.throws(
+    () => {
+      env.registerOperator('Foo < Foo: Foo', () => {})
+    },
+    /Comparison operator '<' must return 'bool', got 'Foo'/
+  )
+
+  assert.throws(
+    () => {
+      env.registerOperator('Foo == Foo: int', () => {})
+    },
+    /Comparison operator '==' must return 'bool', got 'int'/
+  )
+
+  assert.throws(
+    () => {
+      env.registerOperator('Foo in Foo: Foo', () => {})
+    },
+    /Comparison operator 'in' must return 'bool', got 'Foo'/
+  )
+})
+
+test('Operator return types - complex chained operations', () => {
+  class Vec2 {
+    constructor(x, y) {
+      this.x = x
+      this.y = y
+    }
+    add(other) {
+      return new Vec2(this.x + other.x, this.y + other.y)
+    }
+    scale(s) {
+      return new Vec2(this.x * s, this.y * s)
+    }
+    magnitude() {
+      return Math.sqrt(this.x * this.x + this.y * this.y)
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Vec2', Vec2)
+    .registerVariable('v1', 'Vec2')
+    .registerVariable('v2', 'Vec2')
+    .registerVariable('scale', 'double')
+    .registerOperator('Vec2 + Vec2: Vec2', (a, b) => a.add(b))
+    .registerOperator('Vec2 * double: Vec2', (v, s) => v.scale(s))
+    .registerFunction('Vec2.magnitude(): double', (vec) => vec.magnitude())
+
+  // (v1 + v2) * scale should return Vec2
+  const result1 = env.check('(v1 + v2) * scale')
+  assert.strictEqual(result1.valid, true)
+  assert.strictEqual(result1.type, 'Vec2')
+
+  // (v1 + v2).magnitude() should return double
+  const result2 = env.check('(v1 + v2).magnitude()')
+  assert.strictEqual(result2.valid, true)
+  assert.strictEqual(result2.type, 'double')
+
+  // Verify at runtime
+  const v1 = new Vec2(3, 4)
+  const v2 = new Vec2(1, 2)
+  const scaled = env.evaluate('(v1 + v2) * scale', {v1, v2, scale: 2})
+  assert.strictEqual(scaled.x, 8)
+  assert.strictEqual(scaled.y, 12)
+
+  const mag = env.evaluate('(v1 + v2).magnitude()', {v1, v2})
+  assert.strictEqual(mag, Math.sqrt(16 + 36))
+})

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -1,0 +1,634 @@
+import {test} from 'node:test'
+import assert from 'node:assert'
+import {Environment, TypeError} from '../lib/evaluator.js'
+
+test('TypeChecker - valid variable references', () => {
+  const env = new Environment()
+    .registerVariable('name', 'string')
+    .registerVariable('age', 'int')
+    .registerVariable('active', 'bool')
+
+  const result1 = env.check('name')
+  assert.strictEqual(result1.valid, true)
+  assert.strictEqual(result1.type, 'string')
+
+  const result2 = env.check('age')
+  assert.strictEqual(result2.valid, true)
+  assert.strictEqual(result2.type, 'int')
+
+  const result3 = env.check('active')
+  assert.strictEqual(result3.valid, true)
+  assert.strictEqual(result3.type, 'bool')
+})
+
+test('TypeChecker - unknown variable', () => {
+  const env = new Environment().registerVariable('x', 'int')
+
+  const result = env.check('unknownVar')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Unknown variable: unknownVar/)
+})
+
+test('TypeChecker - literals', () => {
+  const env = new Environment()
+
+  assert.strictEqual(env.check('42').type, 'int')
+  assert.strictEqual(env.check('3.14').type, 'double')
+  assert.strictEqual(env.check('"hello"').type, 'string')
+  assert.strictEqual(env.check('true').type, 'bool')
+  assert.strictEqual(env.check('false').type, 'bool')
+  assert.strictEqual(env.check('null').type, 'null')
+  assert.strictEqual(env.check('[1, 2, 3]').type, 'list')
+  // Map literals need key-value pairs
+  const mapResult = env.check('{"a": 1}')
+  assert.strictEqual(mapResult.type, 'map')
+})
+
+test('TypeChecker - arithmetic operators with matching types', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'int')
+    .registerVariable('a', 'double')
+    .registerVariable('b', 'double')
+
+  assert.strictEqual(env.check('x + y').type, 'int')
+  assert.strictEqual(env.check('x - y').type, 'int')
+  assert.strictEqual(env.check('x * y').type, 'int')
+  assert.strictEqual(env.check('x / y').type, 'int')
+  assert.strictEqual(env.check('x % y').type, 'int')
+
+  assert.strictEqual(env.check('a + b').type, 'double')
+  assert.strictEqual(env.check('a - b').type, 'double')
+  assert.strictEqual(env.check('a * b').type, 'double')
+  assert.strictEqual(env.check('a / b').type, 'double')
+})
+
+test('TypeChecker - arithmetic operators with mixed int/double', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('a', 'double')
+
+  // Mixed int/double operations are not defined in overloads
+  // They would require runtime type coercion
+  const result1 = env.check('x + a')
+  assert.strictEqual(result1.valid, false)
+  assert.match(result1.error.message, /Operator '\+' not defined/)
+
+  const result2 = env.check('a + x')
+  assert.strictEqual(result2.valid, false)
+
+  const result3 = env.check('x * a')
+  assert.strictEqual(result3.valid, false)
+})
+
+test('TypeChecker - string concatenation', () => {
+  const env = new Environment()
+    .registerVariable('first', 'string')
+    .registerVariable('last', 'string')
+
+  const result = env.check('first + " " + last')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'string')
+})
+
+test('TypeChecker - list concatenation', () => {
+  const env = new Environment()
+    .registerVariable('list1', 'list')
+    .registerVariable('list2', 'list')
+
+  const result = env.check('list1 + list2')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'list')
+})
+
+test('TypeChecker - invalid arithmetic (string + int)', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerVariable('num', 'int')
+
+  const result = env.check('str + num')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Operator '\+' not defined/)
+})
+
+test('TypeChecker - comparison operators', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'int')
+
+  assert.strictEqual(env.check('x < y').type, 'bool')
+  assert.strictEqual(env.check('x <= y').type, 'bool')
+  assert.strictEqual(env.check('x > y').type, 'bool')
+  assert.strictEqual(env.check('x >= y').type, 'bool')
+  assert.strictEqual(env.check('x == y').type, 'bool')
+  assert.strictEqual(env.check('x != y').type, 'bool')
+})
+
+test('TypeChecker - comparison with incompatible types', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerVariable('num', 'int')
+
+  const result = env.check('str < num')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+})
+
+test('TypeChecker - logical operators', () => {
+  const env = new Environment()
+    .registerVariable('a', 'bool')
+    .registerVariable('b', 'bool')
+
+  assert.strictEqual(env.check('a && b').type, 'bool')
+  assert.strictEqual(env.check('a || b').type, 'bool')
+  assert.strictEqual(env.check('!a').type, 'bool')
+})
+
+test('TypeChecker - logical operators with non-bool', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'int')
+
+  const result = env.check('x && y')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Logical operator requires bool operands/)
+})
+
+test('TypeChecker - ternary operator', () => {
+  const env = new Environment()
+    .registerVariable('condition', 'bool')
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'int')
+
+  const result = env.check('condition ? x : y')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'int')
+})
+
+test('TypeChecker - ternary with non-bool condition', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+
+  const result = env.check('x ? 1 : 2')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Ternary condition must be bool/)
+})
+
+test('TypeChecker - ternary with different branch types', () => {
+  const env = new Environment()
+    .registerVariable('condition', 'bool')
+
+  const result = env.check('condition ? "yes" : 42')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'dyn') // Mixed types return dyn
+})
+
+test('TypeChecker - property access on map', () => {
+  const env = new Environment().registerVariable('obj', 'map')
+
+  const result = env.check('obj.field')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'dyn')
+})
+
+test('TypeChecker - property access on invalid type', () => {
+  const env = new Environment().registerVariable('num', 'int')
+
+  const result = env.check('num.field')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+})
+
+test('TypeChecker - index access on list', () => {
+  const env = new Environment()
+    .registerVariable('list', 'list')
+    .registerVariable('idx', 'int')
+
+  const result = env.check('list[idx]')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'dyn')
+})
+
+test('TypeChecker - index access with invalid index type', () => {
+  const env = new Environment()
+    .registerVariable('list', 'list')
+    .registerVariable('str', 'string')
+
+  const result = env.check('list[str]')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /List index must be int/)
+})
+
+test('TypeChecker - string indexing is not supported', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerVariable('idx', 'int')
+
+  // String indexing is NOT supported in CEL
+  const result = env.check('str[idx]')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Cannot index type 'string'/)
+})
+
+test('TypeChecker - in operator with list', () => {
+  const env = new Environment()
+    .registerVariable('item', 'int')
+    .registerVariable('items', 'list')
+
+  const result = env.check('item in items')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'bool')
+})
+
+test('TypeChecker - in operator with string', () => {
+  const env = new Environment()
+    .registerVariable('substr', 'string')
+    .registerVariable('str', 'string')
+
+  // String in string is NOT supported via the 'in' operator
+  // Use .contains() method instead
+  const result = env.check('substr in str')
+  assert.strictEqual(result.valid, false)
+  assert.match(result.error.message, /Operator 'in' not defined/)
+
+  // This is the correct way:
+  const result2 = env.check('str.contains(substr)')
+  assert.strictEqual(result2.valid, true)
+  assert.strictEqual(result2.type, 'bool')
+})
+
+test('TypeChecker - built-in function size()', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerVariable('list', 'list')
+
+  assert.strictEqual(env.check('size(str)').type, 'int')
+  assert.strictEqual(env.check('size(list)').type, 'int')
+})
+
+test('TypeChecker - built-in function string()', () => {
+  const env = new Environment().registerVariable('num', 'int')
+
+  const result = env.check('string(num)')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'string')
+})
+
+test('TypeChecker - built-in method startsWith()', () => {
+  const env = new Environment().registerVariable('str', 'string')
+
+  const result = env.check('str.startsWith("hello")')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'bool')
+})
+
+test('TypeChecker - method on wrong type', () => {
+  const env = new Environment().registerVariable('num', 'int')
+
+  const result = env.check('num.startsWith("test")')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Method not found/)
+})
+
+test('TypeChecker - custom function', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerFunction('myDouble(int): int', (x) => x * 2n)
+
+  const result = env.check('myDouble(x)')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'int')
+})
+
+test('TypeChecker - custom function with wrong argument type', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerFunction('myDouble(int): int', (x) => x * 2n)
+
+  const result = env.check('myDouble(str)')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /No matching overload/)
+})
+
+test('TypeChecker - unknown function', () => {
+  const env = new Environment()
+
+  const result = env.check('unknownFunc()')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Function not found/)
+})
+
+test('TypeChecker - function overloads', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'double')
+    .registerFunction('convert(int): string', (x) => String(x))
+    .registerFunction('convert(double): string', (x) => String(x))
+
+  assert.strictEqual(env.check('convert(x)').type, 'string')
+  assert.strictEqual(env.check('convert(y)').type, 'string')
+})
+
+test('TypeChecker - complex expression', () => {
+  const env = new Environment()
+    .registerVariable('user', 'map')
+    .registerVariable('minAge', 'int')
+
+  const result = env.check('user.age >= minAge && user.active')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'bool')
+})
+
+test('TypeChecker - macro functions', () => {
+  const env = new Environment().registerVariable('items', 'list')
+
+  // Macros should be accepted (detailed checking happens at runtime)
+  assert.strictEqual(env.check('items.all(i, i > 0)').type, 'bool')
+  assert.strictEqual(env.check('items.exists(i, i > 10)').type, 'bool')
+  assert.strictEqual(env.check('items.map(i, i * 2)').type, 'list')
+  assert.strictEqual(env.check('items.filter(i, i > 5)').type, 'list')
+})
+
+test('TypeChecker - unary minus', () => {
+  const env = new Environment()
+    .registerVariable('x', 'int')
+    .registerVariable('y', 'double')
+
+  assert.strictEqual(env.check('-x').type, 'int')
+  assert.strictEqual(env.check('-y').type, 'double')
+})
+
+test('TypeChecker - unary minus on invalid type', () => {
+  const env = new Environment().registerVariable('str', 'string')
+
+  const result = env.check('-str')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error instanceof TypeError)
+  assert.match(result.error.message, /Unary operator '-' not defined for type/)
+})
+
+test('TypeChecker - dynamic type (dyn)', () => {
+  const env = new Environment({unlistedVariablesAreDyn: true})
+
+  // Unlisted variables are treated as dyn
+  const result = env.check('unknownVar + 10')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'dyn')
+})
+
+test('TypeChecker - nested expressions', () => {
+  const env = new Environment()
+    .registerVariable('a', 'int')
+    .registerVariable('b', 'int')
+    .registerVariable('c', 'int')
+
+  const result = env.check('(a + b) * c - 10')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'int')
+})
+
+test('TypeChecker - method chaining', () => {
+  const env = new Environment().registerVariable('str', 'string')
+
+  const result = env.check('str.substring(0, 5).size()')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'int')
+})
+
+test('TypeChecker - custom types', () => {
+  class Vector {
+    constructor(x, y) {
+      this.x = x
+      this.y = y
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Vector', Vector)
+    .registerVariable('v1', 'Vector')
+    .registerVariable('v2', 'Vector')
+    .registerFunction('Vector.magnitude(): double', function () {
+      return Math.sqrt(this.x * this.x + this.y * this.y)
+    })
+
+  const result = env.check('v1.magnitude()')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'double')
+})
+
+test('TypeChecker - bytes type', () => {
+  const env = new Environment().registerVariable('data', 'bytes')
+
+  assert.strictEqual(env.check('data.size()').type, 'int')
+  assert.strictEqual(env.check('data.string()').type, 'string')
+})
+
+test('TypeChecker - timestamp type', () => {
+  const env = new Environment().registerVariable('ts', 'google.protobuf.Timestamp')
+
+  assert.strictEqual(env.check('ts.getHours()').type, 'int')
+  assert.strictEqual(env.check('ts.getFullYear()').type, 'int')
+})
+
+test('TypeChecker - duration type', () => {
+  const env = new Environment().registerVariable('dur', 'google.protobuf.Duration')
+
+  assert.strictEqual(env.check('dur.getHours()').type, 'int')
+  assert.strictEqual(env.check('dur.getMinutes()').type, 'int')
+})
+
+test('TypeChecker - duration arithmetic', () => {
+  const env = new Environment()
+    .registerVariable('dur1', 'google.protobuf.Duration')
+    .registerVariable('dur2', 'google.protobuf.Duration')
+
+  assert.strictEqual(env.check('dur1 + dur2').type, 'google.protobuf.Duration')
+  assert.strictEqual(env.check('dur1 - dur2').type, 'google.protobuf.Duration')
+})
+
+test('TypeChecker - timestamp and duration arithmetic', () => {
+  const env = new Environment()
+    .registerVariable('ts', 'google.protobuf.Timestamp')
+    .registerVariable('dur', 'google.protobuf.Duration')
+
+  assert.strictEqual(env.check('ts + dur').type, 'google.protobuf.Timestamp')
+  assert.strictEqual(env.check('ts - dur').type, 'google.protobuf.Timestamp')
+
+  // Timestamp - Timestamp is NOT supported in overloads
+  const result = env.check('ts - ts')
+  assert.strictEqual(result.valid, false)
+})
+
+test('TypeChecker - error includes source position', () => {
+  const env = new Environment()
+
+  const result = env.check('unknownVar')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error)
+  assert.ok(result.error.message.includes('Unknown variable: unknownVar'))
+  // Error message should include position highlighting
+  assert.ok(result.error.message.includes('|'))
+  assert.ok(result.error.message.includes('^'))
+})
+
+test('TypeChecker - complex nested validation', () => {
+  const env = new Environment()
+    .registerVariable('users', 'list')
+    .registerVariable('minAge', 'int')
+
+  // Complex expression with macros and comparisons
+  const result = env.check('users.filter(u, u.age >= minAge).map(u, u.name)')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'list')
+})
+
+test('TypeChecker - equality operators support all types', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerVariable('num', 'int')
+
+  // Equality works for same types
+  assert.strictEqual(env.check('str == str').type, 'bool')
+  assert.strictEqual(env.check('num == num').type, 'bool')
+
+  // Cross-type equality is NOT supported (no overload for string == int)
+  const result = env.check('str == num')
+  assert.strictEqual(result.valid, false)
+  assert.match(result.error.message, /Operator '==' not defined/)
+})
+
+test('TypeChecker - parse errors are caught', () => {
+  const env = new Environment()
+
+  const result = env.check('invalid + + syntax')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error)
+})
+
+test('TypeChecker - empty expression', () => {
+  const env = new Environment()
+
+  const result = env.check('')
+  assert.strictEqual(result.valid, false)
+})
+
+test('TypeChecker - uint type support', () => {
+  const env = new Environment()
+    .registerVariable('x', 'uint')
+    .registerVariable('y', 'uint')
+
+  assert.strictEqual(env.check('x + y').type, 'uint')
+  assert.strictEqual(env.check('x < y').type, 'bool')
+})
+
+test('TypeChecker - list index access', () => {
+  const env = new Environment()
+    .registerVariable('list', 'list')
+    .registerVariable('intIndex', 'int')
+    .registerVariable('uintIndex', 'uint')
+    .registerVariable('doubleIndex', 'double')
+    .registerVariable('stringIndex', 'string')
+
+  // Valid: int and uint indices
+  assert.strictEqual(env.check('list[0]').valid, true)
+  assert.strictEqual(env.check('list[intIndex]').valid, true)
+  assert.strictEqual(env.check('list[uintIndex]').valid, true)
+
+  // Invalid: double index
+  const result1 = env.check('list[doubleIndex]')
+  assert.strictEqual(result1.valid, false)
+  assert.ok(result1.error.message.includes('List index must be int or uint'))
+
+  // Invalid: string index
+  const result2 = env.check('list[stringIndex]')
+  assert.strictEqual(result2.valid, false)
+  assert.ok(result2.error.message.includes('List index must be int or uint'))
+
+  // Invalid: double literal
+  const result3 = env.check('list[1.5]')
+  assert.strictEqual(result3.valid, false)
+  assert.ok(result3.error.message.includes('List index must be int or uint'))
+})
+
+test('TypeChecker - list index with dynamic variable', () => {
+  const env = new Environment({unlistedVariablesAreDyn: true})
+    .registerVariable('list', 'list')
+
+  // Dynamic variable is allowed as index (runtime will check)
+  const result = env.check('list[unknownVar]')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'dyn')
+})
+
+test('TypeChecker - map index access', () => {
+  const env = new Environment()
+    .registerVariable('map', 'map')
+    .registerVariable('intKey', 'int')
+    .registerVariable('stringKey', 'string')
+    .registerVariable('doubleKey', 'double')
+
+  // All types are valid as map keys
+  assert.strictEqual(env.check('map["key"]').valid, true)
+  assert.strictEqual(env.check('map[intKey]').valid, true)
+  assert.strictEqual(env.check('map[stringKey]').valid, true)
+  assert.strictEqual(env.check('map[doubleKey]').valid, true)
+  assert.strictEqual(env.check('map[0]').valid, true)
+})
+
+test('TypeChecker - property access', () => {
+  const env = new Environment()
+    .registerVariable('map', 'map')
+    .registerVariable('list', 'list')
+    .registerVariable('num', 'int')
+
+  // Property access allowed on maps and lists
+  assert.strictEqual(env.check('map.property').valid, true)
+  assert.strictEqual(env.check('list.size').valid, true)
+
+  // Property access not allowed on primitives
+  const result = env.check('num.property')
+  assert.strictEqual(result.valid, false)
+  assert.ok(result.error.message.includes('Cannot access property on type'))
+})
+
+test('TypeChecker - string indexing not supported', () => {
+  const env = new Environment()
+    .registerVariable('str', 'string')
+    .registerVariable('index', 'int')
+
+  // String indexing is not supported in CEL
+  const result1 = env.check('str[0]')
+  assert.strictEqual(result1.valid, false)
+  assert.ok(result1.error.message.includes('Cannot index type'))
+
+  const result2 = env.check('str[index]')
+  assert.strictEqual(result2.valid, false)
+  assert.ok(result2.error.message.includes('Cannot index type'))
+})
+
+test('TypeChecker - custom type property access', () => {
+  class Point {
+    constructor(x, y) {
+      this.x = x
+      this.y = y
+    }
+  }
+
+  const env = new Environment()
+    .registerType('Point', Point)
+    .registerVariable('p', 'Point')
+
+  // Property access allowed on custom types
+  const result = env.check('p.x')
+  assert.strictEqual(result.valid, true)
+  assert.strictEqual(result.type, 'dyn')
+})


### PR DESCRIPTION
This PR implements a complete static type checking system for CEL expressions and adds support for return type declarations on custom operator overloads.

## Features

### New Type Checking System

Validates CEL expressions without executing them:

```javascript
const env = new Environment()
  .registerVariable('name', 'string')
  .registerVariable('age', 'int')

// Check expression validity
const result = env.check('name + " is " + string(age)')
console.log(result.valid) // true
console.log(result.type)  // 'string'

// Type error detection
const error = env.check('age + "hello"')
console.log(error.valid)  // false
console.log(error.error.message) // Operator '+' not defined for types 'int' and 'string'
```

### Return Type Declarations for Operators

Custom operators can now specify their return type:

```javascript
// Explicit return type
env.registerOperator('Vector + Vector: Vector', (a, b) => a.add(b))
env.registerOperator('Vector * Vector: double', (a, b) => a.dot(b))

// Defaults to left operand type if not specified
env.registerOperator('Point * double', (a, b) => a.scale(b)) // Returns Point
```

### Comparison Operators Always Return Bool

Comparison operators (`<`, `<=`, `>`, `>=`, `==`, `!=`, `in`) are enforced to return `bool`:

```javascript
// Works - defaults to bool
env.registerOperator('Money < Money', (a, b) => a.amount < b.amount)

// Throws error
env.registerOperator('Money < Money: Money', ...) // ❌ Must return bool
```

### ParseResult.check() Method

Parsed expressions have a `.check()` method for validation without evaluation:

```javascript
const parsed = env.parse('x + y')

// Type check without evaluating
const checkResult = parsed.check()
console.log(checkResult.valid) // true
console.log(checkResult.type)  // 'int'

// Evaluate later with different contexts
const result = parsed({x: 5n, y: 3n}) // 8n
```

### Error Messages with Source Position

TypeError now includes source position highlighting:

```
Operator '+' not defined for types 'int' and 'string'

>    1 | x + "hello"
           ^
```
