### PR TITLE
Fix functions argument in global parse function

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -367,6 +367,7 @@ class Environment {
     if (opts?.supportLegacyFunctions) {
       this.getFunction = this.#getFunctionWithLegacyFunctions
       this.evaluate = this.#evaluateWithLegacyFunctions
+      this.parse = this.#parseWithLegacyFunctions
     }
 
     if (opts?.unlistedVariablesAreDyn) {
@@ -439,14 +440,6 @@ class Environment {
     return this.#variables.has(name)
   }
 
-  parse(expression) {
-    const ast = new Parser(expression).parse()
-    const evaluateParsed = this.#evaluateAST.bind(this, ast)
-    evaluateParsed.check = this.#checkAST.bind(this, ast)
-    evaluateParsed.ast = ast
-    return evaluateParsed
-  }
-
   check(expression) {
     try {
       return {valid: true, type: this.#typeChecker.check(new Parser(expression).parse())}
@@ -461,6 +454,25 @@ class Environment {
     } catch (e) {
       return {valid: false, error: e}
     }
+  }
+
+  #parseWithLegacyFunctions(expression) {
+    const ast = new Parser(expression).parse()
+    const evaluateParsed = (ctx, legacyFunctions) => {
+      this.#legacyFunctions = legacyFunctions
+      return this.#evaluateAST(ast, ctx)
+    }
+    evaluateParsed.check = this.#checkAST.bind(this, ast)
+    evaluateParsed.ast = ast
+    return evaluateParsed
+  }
+
+  parse(expression) {
+    const ast = new Parser(expression).parse()
+    const evaluateParsed = this.#evaluateAST.bind(this, ast)
+    evaluateParsed.check = this.#checkAST.bind(this, ast)
+    evaluateParsed.ast = ast
+    return evaluateParsed
   }
 
   #evaluateWithLegacyFunctions(expression, context, legacyFunctions) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,4 +84,15 @@ describe('CEL Implementation Integration Tests', () => {
     // Should be reasonably fast (less than 100ms for 1000 evaluations)
     t.assert.strictEqual(time < 1000, true, 'Performance test failed - took too long')
   })
+
+  test('supports legacy argument format with functions', (t) => {
+    const context = {a: 5, b: 15}
+    const functions = {
+      max: (x, y) => (x > y ? x : y),
+      min: (x, y) => (x < y ? x : y)
+    }
+
+    t.assert.strictEqual(parse('max(a, b) == 15.0')(context, functions), true)
+    t.assert.strictEqual(evaluate('min(a, b) == 5.0', context, functions), true)
+  })
 })


### PR DESCRIPTION
### Changelog
- 🐛 Fix functions argument in global parse function `parse(expr)(ctx, functions)`, closes #31 


Hint: `parse(expr).check()` does currently not support the legacy functions