### PR TITLE
feat: Support registering functions with `dyn` args

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -683,6 +683,12 @@ class PredicateEvaluator extends Evaluator {
   }
 }
 
+function fnByArgType(fn, argType) {
+  if (!fn) return fn
+
+  return fn[argType] ?? fn.dyn
+}
+
 function resolveFunction(fn, argTypes) {
   if (fn.unknownargs) return fn
 
@@ -690,11 +696,11 @@ function resolveFunction(fn, argTypes) {
     case 0:
       return fn
     case 1:
-      return fn[argTypes[0]]
+      return fnByArgType(fn, argTypes[0])
     case 2:
-      return fn[argTypes[0]]?.[argTypes[1]]
+      return fnByArgType(fnByArgType(fn, argTypes[0]), argTypes[1])
     case 3:
-      return fn[argTypes[0]]?.[argTypes[1]]?.[argTypes[2]]
+      return fnByArgType(fnByArgType(fnByArgType(fn, argTypes[0]), argTypes[1]), argTypes[2])
   }
 }
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -153,7 +153,7 @@ function splitByComma(str) {
 const typesForOperators = new Set(Object.keys(TYPES)).add('null').add('dyn')
 typesForOperators.delete('google')
 
-const typesForFunctions = new Set(Object.keys(TYPES)).add('null').add('ast')
+const typesForFunctions = new Set(Object.keys(TYPES)).add('null').add('dyn').add('ast')
 typesForFunctions.delete('google')
 
 function deepClone(obj) {

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -50,6 +50,26 @@ describe('Environment', () => {
     assert.strictEqual(result1, 42n)
   })
 
+  test('custom dyn functions', () => {
+    const env = new Environment()
+      .registerFunction('length(dyn): int', (x) => x.length)
+      .registerFunction('run(dyn): dyn', (obj) => obj ?? 42)
+
+    // Dynamically typed arg
+    const result1 = env.evaluate('length("hello")')
+    assert.strictEqual(result1, 5)
+
+    const result2 = env.evaluate('length([1, 2, 3])')
+    assert.strictEqual(result2, 3)
+
+    // Dynamically typed arg and return values
+    const result3 = env.evaluate('run("hello")')
+    assert.strictEqual(result3, "hello")
+
+    const result4 = env.evaluate('run(null)')
+    assert.strictEqual(result4, 42)
+  })
+
   test('chaining methods', () => {
     const env = new Environment()
       .registerVariable('x', 'int')


### PR DESCRIPTION
I'm utilising `cel-js` as a validator and parser on the frontend as a counterpoint the the Go-based implementation (https://github.com/google/cel-go) and have several functions defined to accept `decls.Dyn` type arguments:

```go
decls.NewFunction("count",
	decls.NewOverload("count_dyn", []*exprpb.Type{decls.Dyn}, decls.Int),
)
```

This definition works with `cel-go`, but not with `cel-js` because `dyn` isn't currently allowed as a type in the function signature, per `typesForFunctions`. https://github.com/marcbachmann/cel-js/blob/d5515db5132b6e34c6f9f98041cb3f5253e31468/lib/registry.js#L156

This PR has a suggested solution - it adds `dyn` into `typesForFunctions` and adjusts `resolveFunction` to look up either the concrete type or `dyn`, should it exist. Let me know what you think and if anything else needs changing.

With `cel-go`, overlapping overloads aren't permitted and will error, so these are mutually exclusive and the change here doesn't need to handle precedence between the two.  However, I did notice that `cel-js` allows registering another function like `length(int): int` in the test I've added, which overlaps with `length(dyn): int`; so this may want adjusting at some point.