### PR TITLE
feat: expose `node` on errors

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,16 +1,22 @@
 export class ParseError extends Error {
   #wasConstructedWithAst = false
+  #node
   constructor(message, node, cause) {
     super(message, {cause})
     this.name = 'ParseError'
+    this.#node = node
 
     if (!node?.input) return
-    this.#wasConstructedWithAst = true
     this.message = formatErrorWithHighlight(this.message, node)
   }
 
+  get node() {
+    return this.#node
+  }
+
   withAst(node) {
-    if (this.#wasConstructedWithAst) return this
+    if (this.#node) return this
+    this.#node = node
     if (!node?.input) return this
     this.message = formatErrorWithHighlight(this.message, node)
     return this
@@ -18,18 +24,23 @@ export class ParseError extends Error {
 }
 
 export class EvaluationError extends Error {
-  #wasConstructedWithAst = false
+  #node
   constructor(message, node, cause) {
     super(message, {cause})
     this.name = 'EvaluationError'
+    this.#node = node
 
     if (!node?.input) return
-    this.#wasConstructedWithAst = true
     this.message = formatErrorWithHighlight(this.message, node)
   }
 
+  get node() {
+    return this.#node
+  }
+
   withAst(node) {
-    if (this.#wasConstructedWithAst) return this
+    if (this.#node) return this
+    this.#node = node
     if (!node?.input) return this
     this.message = formatErrorWithHighlight(this.message, node)
     return this
@@ -37,18 +48,23 @@ export class EvaluationError extends Error {
 }
 
 export class TypeError extends Error {
-  #wasConstructedWithAst = false
+  #node
   constructor(message, node, cause) {
     super(message, {cause})
     this.name = 'TypeError'
+    this.#node = node
 
     if (!node?.input) return
-    this.#wasConstructedWithAst = true
     this.message = formatErrorWithHighlight(this.message, node)
   }
 
+  get node() {
+    return this.#node
+  }
+
   withAst(node) {
-    if (this.#wasConstructedWithAst) return this
+    if (this.#node) return this
+    this.#node = node
     if (!node?.input) return this
     this.message = formatErrorWithHighlight(this.message, node)
     return this

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,12 +10,32 @@ describe('CEL Implementation Integration Tests', () => {
   })
 
   test('should handle parse errors gracefully', (t) => {
-    t.assert.throws(() => parse('1 +'), Error)
+    t.assert.throws(() => parse('1 +'), {
+      name: 'ParseError',
+      node: {
+        input: '1 +',
+        pos: 3
+      }
+    })
   })
 
   test('should handle evaluation errors', (t) => {
-    t.assert.throws(() => evaluate('unknownVar'), /Unknown variable: unknownVar/)
-    t.assert.throws(() => evaluate('obj.prop', {obj: null}), /No such key: prop/)
+    t.assert.throws(() => evaluate('unknownVar'), (err) => {
+      t.assert.ok(err instanceof EvaluationError)
+      t.assert.match(err.message, /Unknown variable: unknownVar/)
+      t.assert.strictEqual(err.node[0], 'id')
+      t.assert.strictEqual(err.node[1], 'unknownVar')
+      return true;
+    })
+    t.assert.throws(() => evaluate('obj.prop', {obj: null}), (err) => {
+      t.assert.ok(err instanceof EvaluationError)
+      t.assert.match(err.message, /No such key: prop/)
+      t.assert.strictEqual(err.node[0], '.')
+      t.assert.strictEqual(err.node[1][0], 'id')
+      t.assert.strictEqual(err.node[1][1], 'obj')
+      t.assert.strictEqual(err.node[2], 'prop')
+      return true;
+    })
   })
 
   test('should work with parse function directly', (t) => {

--- a/test/type-checker.test.js
+++ b/test/type-checker.test.js
@@ -28,6 +28,8 @@ describe('Type Checker', () => {
     assert.strictEqual(result.valid, false)
     assert.ok(result.error instanceof TypeError)
     assert.match(result.error.message, /Unknown variable: unknownVar/)
+    assert.strictEqual(result.error.node[0], 'id')
+    assert.strictEqual(result.error.node[1], 'unknownVar')
   })
 
   test('literals', () => {
@@ -109,6 +111,11 @@ describe('Type Checker', () => {
     assert.strictEqual(result.valid, false)
     assert.ok(result.error instanceof TypeError)
     assert.match(result.error.message, /no such overload: string \+ int/)
+    assert.strictEqual(result.error.node[0], '+')
+    assert.strictEqual(result.error.node[1][0], 'id')
+    assert.strictEqual(result.error.node[1][1], 'str')
+    assert.strictEqual(result.error.node[2][0], 'id')
+    assert.strictEqual(result.error.node[2][1], 'num')
   })
 
   test('comparison operators', () => {


### PR DESCRIPTION
Implements #37 to expose the `node` object associated with each error, for use by a caller in directly identifying the problem and problematic parts of an expression. 