### PR TITLE
Fix function overloads with typed variables

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -70,14 +70,16 @@ const handlers = new Map(
     rcall(ast, ev) {
       const functionName = ast[1]
       const receiver = ev.eval(ast[2])
-      let args = ast[3]
+      const checkedType = ast[2].checkedType || ev.celTypes.dyn
+      const argAst = ast[3]
+      const argLen = argAst.length
       const functionCandidates = (ast.functionCandidates ??= ev.registry.getFunctionCandidates(
-        ast[2].checkedType || ev.celTypes.dyn,
+        checkedType,
         functionName,
-        args.length
+        argLen
       ))
 
-      const receiverType = ev.debugType(receiver)
+      const receiverType = checkedType.kind !== 'dyn' ? checkedType : ev.debugType(receiver)
       if (!functionCandidates.exists) {
         throw new EvaluationError(
           `Function not found: '${functionName}' for value of type '${receiverType}'`,
@@ -87,12 +89,19 @@ const handlers = new Map(
 
       const byReceiver = functionCandidates.filterByReceiverType(receiverType)
 
+      let args
       let argTypes
       if (byReceiver.hasMacro) {
-        argTypes = ast.macroArgTypes ??= args.map(() => ev.registry.getFunctionType('ast'))
+        args = argAst
+        argTypes = ast.argMacroTypes ??= new Array(argLen).fill(ev.registry.getFunctionType('ast'))
       } else {
-        args = args.map(ev.eval, ev)
-        argTypes = args.map(ev.debugType, ev)
+        args = ast.argValues ??= new Array(argLen)
+        argTypes = ast.argTypes ??= new Array(argLen)
+        for (let i = 0; i < argLen; i++) {
+          const arg = argAst[i]
+          args[i] = ev.eval(arg)
+          argTypes[i] = getFunctionArgType(arg.checkedType, ev.debugType(args[i]), ev)
+        }
       }
 
       const decl = byReceiver.findMatch(argTypes)
@@ -116,11 +125,12 @@ const handlers = new Map(
     },
     call(ast, ev) {
       const functionName = ast[1]
-      let args = ast[2]
+      const argAst = ast[2]
+      const argLen = argAst.length
       const functionCandidates = (ast.functionCandidates ??= ev.registry.getFunctionCandidates(
         null,
         functionName,
-        args.length
+        argLen
       ))
 
       if (functionCandidates.exists === false) {
@@ -129,12 +139,19 @@ const handlers = new Map(
 
       const byReceiver = functionCandidates.filterByReceiverType(null)
 
+      let args
       let argTypes
       if (functionCandidates.hasMacro) {
-        argTypes = ast.macroArgTypes ??= args.map(() => ev.registry.getFunctionType('ast'))
+        args = argAst
+        argTypes = ast.argMacroTypes ??= new Array(argLen).fill(ev.registry.getFunctionType('ast'))
       } else {
-        args = args.map(ev.eval, ev)
-        argTypes = args.map(ev.debugType, ev)
+        args = ast.argValues ??= new Array(argLen)
+        argTypes = ast.argTypes ??= new Array(argLen)
+        for (let i = 0; i < argLen; i++) {
+          const arg = argAst[i]
+          args[i] = ev.eval(arg)
+          argTypes[i] = getFunctionArgType(arg.checkedType, ev.debugType(args[i]), ev)
+        }
       }
 
       const decl = byReceiver.findMatch(argTypes)
@@ -212,9 +229,21 @@ function binaryOverload(ast, ev) {
 }
 
 function getOperandType(checkedType, runtimeType, ev) {
-  if (!checkedType) return runtimeType
-  if (checkedType.kind !== 'dyn') return checkedType
-  return ev.registry.getDynType(runtimeType)
+  if (checkedType === runtimeType || !checkedType) return runtimeType
+  if (checkedType.kind === 'dyn') return ev.registry.getDynType(runtimeType)
+  if (checkedType.kind !== runtimeType.kind) {
+    throw new EvaluationError(`Type mismatch: expected ${checkedType}, got ${runtimeType}`)
+  }
+
+  return checkedType
+}
+
+function getFunctionArgType(checkedType, runtimeType) {
+  if (checkedType === runtimeType || !checkedType || checkedType.kind === 'dyn') return runtimeType
+  if (checkedType.kind !== runtimeType.kind) {
+    throw new EvaluationError(`Type mismatch: expected ${checkedType}, got ${runtimeType}`)
+  }
+  return checkedType
 }
 
 class Context {

--- a/test/built-in-functions.test.js
+++ b/test/built-in-functions.test.js
@@ -740,7 +740,7 @@ describe('built-in functions', () => {
       )
       t.assert.throws(
         () => evaluate('double([1, 2, 3])'),
-        /found no matching overload for 'double\(list<dyn>\)'/
+        /found no matching overload for 'double\(list<int>\)'/
       )
       t.assert.throws(
         () => evaluate('double(bytes("test"))'),

--- a/test/custom-functions.test.js
+++ b/test/custom-functions.test.js
@@ -1,0 +1,22 @@
+import {describe, test} from 'node:test'
+import assert from 'node:assert'
+import {Environment} from '../lib/evaluator.js'
+
+describe('Custom functions', () => {
+  test('resolves overloads correctly according to the type check', () => {
+    const env = new Environment()
+      .registerVariable('i', 'int')
+      .registerVariable('il', 'list<int>')
+      .registerVariable('b', 'bool')
+      .registerVariable('bl', 'list<bool>')
+      .registerFunction('max(list<bool>): bool', (list) => true)
+      .registerFunction('max(list<int>): int', (list) => 42)
+
+    assert.equal(env.evaluate('max([1])'), 42)
+    assert.equal(env.evaluate('max([i])', {i: 1n}), 42)
+    assert.equal(env.evaluate('max(il)', {il: [1n]}), 42)
+    assert.equal(env.evaluate('max([false])'), true)
+    assert.equal(env.evaluate('max([b])', {b: false}), true)
+    assert.equal(env.evaluate('max(bl)', {bl: [false]}), true)
+  })
+})


### PR DESCRIPTION
Fixed #43 partially

### Changelog
- 🐛 Fix function overloads with typed variables


Those cases still fail, but till that's fixed this improves the behavior slightly.
```
  test('resolves overloads correctly according to the type check with dyn', () => {
    const env = new Environment()
      .registerVariable('d', 'dyn')
      .registerFunction('max(list<bool>): bool', (list) => true)
      .registerFunction('max(list<int>): int', (list) => 42)

    assert.equal(env.evaluate('max([d])', {d: 1n}), 42)
    assert.equal(env.evaluate('max(d)', {d: [1n]}), 42)
    assert.equal(env.evaluate('max([dyn(1)])'), 42)
  })
```