### PR TITLE
Support `homogeneousAggregateLiterals` option on the Evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,13 @@ env.evaluate('"Hi" * 3') // "HiHiHi"
 ```javascript
 new Environment({
   // Treat undeclared variables as dynamic type
-  unlistedVariablesAreDyn: false
+  unlistedVariablesAreDyn: false,
+  // Require list/map literals to stay strictly homogeneous (default: true)
+  homogeneousAggregateLiterals: true
 })
 ```
+
+Set `homogeneousAggregateLiterals` to `false` if you need aggregate literals to accept mixed element/key/value types without wrapping everything in `dyn(...)`.
 
 #### Environment Methods
 

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -271,7 +271,7 @@ class Context {
 }
 
 class RootContext extends Context {
-  constructor({variables, fallbackValues}) {
+  constructor(variables, fallbackValues) {
     super()
     this.variables = variables
     this.fallbackValues = fallbackValues
@@ -352,7 +352,8 @@ class Environment {
         ? registryByEnvironment.get(opts.inherit)
         : globalRegistry
     ).clone({
-      unlistedVariablesAreDyn: opts?.unlistedVariablesAreDyn ?? false
+      unlistedVariablesAreDyn: opts?.unlistedVariablesAreDyn ?? false,
+      homogeneousAggregateLiterals: opts?.homogeneousAggregateLiterals ?? true
     })
 
     this.#variables = this.#registry.variables
@@ -362,10 +363,8 @@ class Environment {
       variables: this.#variables,
       objectTypes: this.#registry.objectTypes,
       objectTypesByConstructor: this.#registry.objectTypesByConstructor,
-      ctx: new RootContext({
-        variables: this.#variables,
-        fallbackValues: globalValues
-      })
+      homogeneousAggregateLiterals: opts?.homogeneousAggregateLiterals ?? true,
+      ctx: new RootContext(this.#variables, globalValues)
     }
 
     this.#typeChecker = new TypeChecker(childOpts)
@@ -379,7 +378,10 @@ class Environment {
   clone(opts) {
     return new Environment({
       inherit: this,
-      unlistedVariablesAreDyn: this.#opts?.unlistedVariablesAreDyn ?? false
+      unlistedVariablesAreDyn:
+        opts?.unlistedVariablesAreDyn ?? this.#opts?.unlistedVariablesAreDyn ?? false,
+      homogeneousAggregateLiterals:
+        opts?.homogeneousAggregateLiterals ?? this.#opts?.homogeneousAggregateLiterals ?? true
     })
   }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -142,6 +142,11 @@ export interface EnvironmentOptions {
    * When false, all variables must be explicitly registered.
    */
   unlistedVariablesAreDyn?: boolean
+  /**
+   * When true (default), list and map literals must have homogeneous element/key/value types.
+   * When false, mixed literals are inferred as list<dyn> or map with dyn components.
+   */
+  homogeneousAggregateLiterals?: boolean
 }
 
 /**

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -252,12 +252,12 @@ export class TypeDeclaration {
   #matches(other) {
     const s = this.unwrappedType
     const o = other.unwrappedType
-
-    if (s === o) return true
-    if (o.kind === 'dyn') return true
+    if (s === o || o.kind === 'dyn') return true
+    if (o.kind === 'param') return false
 
     switch (s.kind) {
       case 'dyn':
+      case 'param':
         return true
       case 'list':
         return o.kind === 'list' && s.valueType.matches(o.valueType)
@@ -871,7 +871,7 @@ export class Registry {
     return all
   }
 
-  clone(opts = {}) {
+  clone(opts) {
     return new Registry({
       objectTypes: this.objectTypes,
       objectTypesByConstructor: this.objectTypesByConstructor,
@@ -880,7 +880,7 @@ export class Registry {
       operatorDeclarations: this.#operatorDeclarations,
       functionDeclarations: this.#functionDeclarations,
       variables: this.variables,
-      unlistedVariablesAreDyn: opts.unlistedVariablesAreDyn
+      unlistedVariablesAreDyn: opts?.unlistedVariablesAreDyn
     })
   }
 
@@ -922,12 +922,9 @@ export class Registry {
       !isDifferentReceiver &&
       (b.macro ||
         a.macro ||
-        b.argTypes.every((type1, i) => {
-          const type2 = a.argTypes[i]
-          if (type1 === type2) return true
-          if (type1 === astType || type2 === astType) return true
-          if (type1 === dynType || type2 === dynType) return true
-          return false
+        b.argTypes.every((t, i) => {
+          const o = a.argTypes[i]
+          return t === o || t === astType || o === astType || t === dynType || o === dynType
         }))
     )
   }
@@ -942,11 +939,9 @@ export class Registry {
     }
   }
 
-  registerFunctionOverload(s, handlerOrOptions) {
-    const handler =
-      typeof handlerOrOptions === 'function' ? handlerOrOptions : handlerOrOptions.handler
-    const options = typeof handlerOrOptions === 'function' ? {} : handlerOrOptions
-
+  registerFunctionOverload(s, _opts) {
+    const handler = typeof _opts === 'function' ? _opts : _opts.handler
+    const options = typeof _opts === 'function' ? {} : _opts
     const dec = this.#parseFunctionDeclaration(s, handler, options.typeCheck)
     this.#checkOverlappingSignatures(dec)
     this.#functionDeclarations.set(dec.signature, dec)

--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -9,13 +9,14 @@ import {TypeError, EvaluationError} from './errors.js'
  * - Property and index access validity
  */
 export class TypeChecker {
-  constructor({ctx, objectTypes, objectTypesByConstructor, registry, isEvaluating = false}) {
-    this.ctx = ctx
-    this.objectTypes = objectTypes
-    this.objectTypesByConstructor = objectTypesByConstructor
-    this.registry = registry
-    this.isEvaluating = isEvaluating
-    this.Error = isEvaluating ? EvaluationError : TypeError
+  constructor(opts) {
+    this.ctx = opts.ctx
+    this.objectTypes = opts.objectTypes
+    this.objectTypesByConstructor = opts.objectTypesByConstructor
+    this.registry = opts.registry
+    this.isEvaluating = opts.isEvaluating
+    this.homogeneousAggregateLiterals = opts.homogeneousAggregateLiterals
+    this.Error = opts.isEvaluating ? EvaluationError : TypeError
   }
 
   /**
@@ -33,7 +34,8 @@ export class TypeChecker {
       objectTypes: this.objectTypes,
       objectTypesByConstructor: this.objectTypesByConstructor,
       registry: this.registry,
-      isEvaluating: this.isEvaluating
+      isEvaluating: this.isEvaluating,
+      homogeneousAggregateLiterals: this.homogeneousAggregateLiterals
     })
   }
 
@@ -228,49 +230,57 @@ export class TypeChecker {
     return decl.returnType
   }
 
-  checkList(ast) {
-    const elements = ast[1]
-    if (elements.length === 0) return this.getType(`list`)
+  #checkElementHomogenous(expected, el, m) {
+    const type = this.check(el)
+    if (type === expected) return type
+    let prefix
+    if (m === 0) prefix = 'List elements must have the same type,'
+    else if (m === 1) prefix = 'Map key uses wrong type,'
+    else if (m === 2) prefix = 'Map value uses wrong type,'
+    throw new this.Error(`${prefix} expected type '${expected}' but found '${type}'`, el)
+  }
 
-    const firstType = this.check(elements[0])
-    for (let i = 1; i < elements.length; i++) {
-      const type = this.check(elements[i])
-      if (firstType === type) continue
-      throw new this.Error(
-        `List elements must have the same type, got '${firstType}' and '${type}'`,
-        ast
-      )
-    }
-    return this.getType(`list<${firstType}>`)
+  #checkElement(expected, el) {
+    const candidate = this.check(el)
+    if (expected === candidate) return expected
+    if (expected.kind === 'dyn') return expected
+    if (candidate.kind === 'dyn') return candidate
+    if (expected.matches(candidate)) return expected
+    if (candidate.matches(expected)) return candidate
+    return this.getType('dyn')
+  }
+
+  checkList(ast) {
+    const arr = ast[1]
+    const arrLen = arr.length
+    if (arrLen === 0) return this.getType(`list`)
+
+    let valueType = this.check(arr[0])
+    const check = this.homogeneousAggregateLiterals
+      ? this.#checkElementHomogenous
+      : this.#checkElement
+
+    for (let i = 1; i < arrLen; i++) valueType = check.call(this, valueType, arr[i], 0)
+    return this.getType(`list<${valueType}>`)
   }
 
   checkMap(ast) {
-    const entries = ast[1]
-    if (entries.length === 0) return this.getType('map')
+    const arr = ast[1]
+    const arrLen = arr.length
+    if (arrLen === 0) return this.getType('map')
 
-    const firstKeyType = this.check(entries[0][0])
-    const firstValueType = this.check(entries[0][1])
+    const checkElement = this.homogeneousAggregateLiterals
+      ? this.#checkElementHomogenous
+      : this.#checkElement
 
-    for (let i = 1; i < entries.length; i++) {
-      const [key, value] = entries[i]
-      const keyType = this.check(key)
-      if (firstKeyType !== keyType) {
-        throw new this.Error(
-          `Map key uses wrong type, expected type '${firstKeyType}' but found '${keyType}'.`,
-          ast
-        )
-      }
-
-      const valueType = this.check(value)
-      if (firstValueType !== valueType) {
-        throw new this.Error(
-          `Map value uses wrong type, expected type '${firstValueType}' but found '${valueType}'.`,
-          ast
-        )
-      }
+    let keyType = this.check(arr[0][0])
+    let valueType = this.check(arr[0][1])
+    for (let i = 1; i < arrLen; i++) {
+      const [keyAst, valueAst] = arr[i]
+      keyType = checkElement.call(this, keyType, keyAst, 1)
+      valueType = checkElement.call(this, valueType, valueAst, 2)
     }
-
-    return this.getType(`map<${firstKeyType}, ${firstValueType}>`)
+    return this.getType(`map<${keyType}, ${valueType}>`)
   }
 
   checkTernary(ast) {

--- a/test/lists.test.js
+++ b/test/lists.test.js
@@ -15,33 +15,57 @@ describe('lists expressions', () => {
       t.assert.deepStrictEqual(evaluate('[1, 2, 3]'), [1n, 2n, 3n])
     })
 
-    test('should not support mixed lists', (t) => {
+    test('rejects mixed lists by default', (t) => {
       t.assert.throws(
-        () => evaluate('[1, 1.0]', {i: 2}),
-        /List elements must have the same type, got 'int' and 'double'/
+        () => evaluate('[1, 1.0]'),
+        /List elements must have the same type, expected type 'int' but found 'double'/
       )
 
       t.assert.throws(
-        () => evaluate('[[1], [1.0]]', {i: 2}),
-        /List elements must have the same type, got 'list<int>' and 'list<double>'/
+        () => evaluate('[[1], [1.0]]'),
+        /List elements must have the same type, expected type 'list<int>' but found 'list<double>'/
       )
 
       t.assert.throws(
         () => evaluate('[[1], [i]]', {i: 2}),
-        /List elements must have the same type, got 'list<int>' and 'list<dyn>'/
+        /List elements must have the same type, expected type 'list<int>' but found 'list<dyn>'/
       )
 
       t.assert.throws(
         () => evaluate('[1, "hello", true, null]'),
-        /List elements must have the same type, got 'int' and 'string'/
+        /List elements must have the same type, expected type 'int' but found 'string'/
       )
 
       t.assert.throws(
         () => evaluate('[dyn(1), "hello", true, null]'),
-        /List elements must have the same type, got 'dyn' and 'string'/
+        /List elements must have the same type, expected type 'dyn' but found 'string'/
       )
 
       evaluate('[dyn(1), dyn("hello"), dyn(true), dyn(null)]')
+    })
+
+    test('allows mixed lists when explicitly disabled', (t) => {
+      const env = new Environment({
+        homogeneousAggregateLiterals: false,
+        unlistedVariablesAreDyn: true
+      })
+
+      t.assert.deepStrictEqual(env.evaluate('[1, 1.0]'), [1n, 1])
+      t.assert.deepStrictEqual(env.evaluate('[[1], [1.0]]'), [[1n], [1]])
+      t.assert.deepStrictEqual(env.evaluate('[[1], [i]]', {i: 2}), [[1n], [2]])
+      t.assert.deepStrictEqual(env.evaluate('[1, "hello", true, null]'), [1n, 'hello', true, null])
+      t.assert.deepStrictEqual(env.evaluate('[dyn(1), "hello", true, null]'), [
+        1n,
+        'hello',
+        true,
+        null
+      ])
+      t.assert.deepStrictEqual(env.evaluate('[dyn(1), dyn("hello"), dyn(true), dyn(null)]'), [
+        1n,
+        'hello',
+        true,
+        null
+      ])
     })
   })
 

--- a/test/macros.test.js
+++ b/test/macros.test.js
@@ -35,7 +35,10 @@ describe('macros', () => {
     })
 
     test('should throw when a nested property does not exist', (t) => {
-      t.assert.throws(() => evaluate('has(user.nonExisting.foo)', context), /No such key: nonExisting/)
+      t.assert.throws(
+        () => evaluate('has(user.nonExisting.foo)', context),
+        /No such key: nonExisting/
+      )
 
       t.assert.throws(
         () => evaluate('has(user.profile.nonExisting.bar)', context),


### PR DESCRIPTION
### Changelog
- 🎁 Introduce the `homogeneousAggregateLiterals` option (defaults to `true`) so users can keep list/map literals strictly homogeneous or opt out to mixed aggregates.
  e.g.
  - Strict (default): `new Environment().evaluate('[1, "two"])` → error because int/string mismatch.
  - Permissive: `new Environment({homogeneousAggregateLiterals: false}).evaluate('[1, "two"])` → succeeds with inferred `list<dyn>` type.
  - Dyn-only mix: `[dyn(1), dyn("two")]` still allowed even when strict mode is on.
