### PR TITLE
Introduce limits options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ new Environment({
   unlistedVariablesAreDyn: false,
   // Require list/map literals to stay strictly homogeneous (default: true)
   homogeneousAggregateLiterals: true
+  // Optional structural limits (parse time)
+  limits: {
+    maxAstNodes: 100000,
+    maxDepth: 250,
+    maxListElements: 1000,
+    maxMapEntries: 1000,
+    maxCallArguments: 32
+  }
 })
 ```
 

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -4,6 +4,7 @@ import {registerFunctions, Duration, UnsignedInt} from './functions.js'
 import {registerOverloads} from './overloads.js'
 import {TypeChecker} from './type-checker.js'
 import {Parser} from './parser.js'
+import {createOptions} from './options.js'
 
 const globalRegistry = createRegistry()
 registerOverloads(globalRegistry)
@@ -253,11 +254,7 @@ function getOperandType(checkedType, value, ev) {
 
 class Context {
   createOverlay(name, type) {
-    return new OverlayContext({
-      parent: this,
-      variableName: name,
-      variableType: type
-    })
+    return new OverlayContext(this, name, type)
   }
 
   getVariable(name) {
@@ -311,7 +308,7 @@ class RootContext extends Context {
 }
 
 class OverlayContext extends Context {
-  constructor({parent, variableName, variableType}) {
+  constructor(parent, variableName, variableType) {
     super()
     this.parent = parent
     this.variableName = variableName
@@ -338,51 +335,33 @@ const registryByEnvironment = new WeakMap()
 const globalValues = new Map(Object.entries(TYPES))
 
 class Environment {
-  #variables
   #registry
   #evaluator
   #typeChecker
-  #opts
 
-  constructor(opts) {
-    this.#opts = opts
-
+  constructor(opts, inherited) {
+    this.opts = createOptions(opts, inherited?.opts)
     this.#registry = (
-      opts?.inherit instanceof Environment
-        ? registryByEnvironment.get(opts.inherit)
-        : globalRegistry
-    ).clone({
-      unlistedVariablesAreDyn: opts?.unlistedVariablesAreDyn ?? false,
-      homogeneousAggregateLiterals: opts?.homogeneousAggregateLiterals ?? true
-    })
-
-    this.#variables = this.#registry.variables
+      inherited instanceof Environment ? registryByEnvironment.get(inherited) : globalRegistry
+    ).clone(this.opts)
 
     const childOpts = {
       registry: this.#registry,
-      variables: this.#variables,
       objectTypes: this.#registry.objectTypes,
       objectTypesByConstructor: this.#registry.objectTypesByConstructor,
-      homogeneousAggregateLiterals: opts?.homogeneousAggregateLiterals ?? true,
-      ctx: new RootContext(this.#variables, globalValues)
+      opts: this.opts,
+      ctx: new RootContext(this.#registry.variables, globalValues)
     }
 
-    this.#typeChecker = new TypeChecker(childOpts)
-
-    const evaluateTypeChecker = new TypeChecker({...childOpts, isEvaluating: true})
-    this.#evaluator = new Evaluator({...childOpts, typeChecker: evaluateTypeChecker})
+    this.#typeChecker = new TypeChecker(childOpts.ctx, childOpts)
+    const evaluateTypeChecker = new TypeChecker(childOpts.ctx, childOpts, true)
+    this.#evaluator = new Evaluator(childOpts, evaluateTypeChecker)
     registryByEnvironment.set(this, this.#registry)
     Object.freeze(this)
   }
 
   clone(opts) {
-    return new Environment({
-      inherit: this,
-      unlistedVariablesAreDyn:
-        opts?.unlistedVariablesAreDyn ?? this.#opts?.unlistedVariablesAreDyn ?? false,
-      homogeneousAggregateLiterals:
-        opts?.homogeneousAggregateLiterals ?? this.#opts?.homogeneousAggregateLiterals ?? true
-    })
+    return new Environment(opts, this)
   }
 
   registerFunction(string, handler) {
@@ -411,7 +390,7 @@ class Environment {
 
   check(expression) {
     try {
-      const typeDecl = this.#typeChecker.check(new Parser(expression).parse())
+      const typeDecl = this.#typeChecker.check(new Parser(expression, this.opts.limits).parse())
       return {valid: true, type: this.#formatTypeForCheck(typeDecl)}
     } catch (e) {
       return {valid: false, error: e}
@@ -434,7 +413,7 @@ class Environment {
   }
 
   parse(expression) {
-    const ast = new Parser(expression).parse()
+    const ast = new Parser(expression, this.opts.limits).parse()
     const evaluateParsed = this.#evaluateAST.bind(this, ast)
     evaluateParsed.check = this.#checkAST.bind(this, ast)
     evaluateParsed.ast = ast
@@ -442,7 +421,7 @@ class Environment {
   }
 
   evaluate(expression, context) {
-    return this.#evaluateAST(new Parser(expression).parse(), context)
+    return this.#evaluateAST(new Parser(expression, this.opts.limits).parse(), context)
   }
 
   #evaluateAST(ast, context = null) {
@@ -460,12 +439,13 @@ function unsupportedType(type) {
 class Evaluator {
   handlers = handlers
   celTypes = celTypes
-  constructor({registry, objectTypes, objectTypesByConstructor, typeChecker, ctx}) {
+  constructor({registry, objectTypes, objectTypesByConstructor, ctx, limits}, typeChecker) {
     this.objectTypes = objectTypes
     this.objectTypesByConstructor = objectTypesByConstructor
     this.registry = registry
     this.typeChecker = typeChecker
     this.ctx = ctx
+    this.limits = limits
   }
 
   value(name, ast) {
@@ -560,7 +540,7 @@ class Evaluator {
 
 class PredicateEvaluator extends Evaluator {
   constructor(e, functionName, ast) {
-    super(e)
+    super(e, e.typeChecker)
 
     const [identifier, predicate] = ast[3]
     if (identifier?.[0] !== 'id') {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -134,6 +134,23 @@ export function evaluate(expression: string, context?: Context): any
 export function serialize(ast: ASTNode): string
 
 /**
+ * Structural limits for parsing and evaluating CEL expressions.
+ * All limits default to the minimums required by the CEL specification.
+ */
+export interface Limits {
+  /** Maximum number of AST nodes that can be produced while parsing */
+  maxAstNodes: number
+  /** Maximum nesting depth for recursive grammar elements (calls, selects, indexes, aggregates) */
+  maxDepth: number
+  /** Maximum number of list literal elements */
+  maxListElements: number
+  /** Maximum number of map literal entries */
+  maxMapEntries: number
+  /** Maximum number of function or method call arguments */
+  maxCallArguments: number
+}
+
+/**
  * Options for creating a new Environment.
  */
 export interface EnvironmentOptions {
@@ -147,6 +164,8 @@ export interface EnvironmentOptions {
    * When false, mixed literals are inferred as list<dyn> or map with dyn components.
    */
   homogeneousAggregateLiterals?: boolean
+  /** Optional overrides for parser/evaluator structural limits */
+  limits?: Partial<Limits>
 }
 
 /**

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,43 @@
+const DEFAULT_LIMITS = Object.freeze({
+  maxAstNodes: 100000,
+  maxDepth: 250,
+  maxListElements: 1000,
+  maxMapEntries: 1000,
+  maxCallArguments: 32
+})
+
+const LIMIT_KEYS = new Set(Object.keys(DEFAULT_LIMITS))
+function createLimits(overrides, base = DEFAULT_LIMITS) {
+  const keys = overrides ? Object.keys(overrides) : undefined
+  if (!keys?.length) return base
+
+  const merged = {...base}
+  for (const key of keys) {
+    if (!LIMIT_KEYS.has(key)) throw new TypeError(`Unknown limits option: ${key}`)
+    const value = overrides[key]
+    if (typeof value !== 'number') continue
+    merged[key] = value
+  }
+  return Object.freeze(merged)
+}
+
+const DEFAULT_OPTIONS = Object.freeze({
+  unlistedVariablesAreDyn: false,
+  homogeneousAggregateLiterals: true,
+  limits: DEFAULT_LIMITS
+})
+
+function bool(a, b, key) {
+  const value = a?.[key] ?? b?.[key]
+  if (typeof value !== 'boolean') throw new TypeError(`Invalid option: ${key}`)
+  return value
+}
+
+export function createOptions(opts, base = DEFAULT_OPTIONS) {
+  if (!opts) return base
+  return Object.freeze({
+    unlistedVariablesAreDyn: bool(opts, base, 'unlistedVariablesAreDyn'),
+    homogeneousAggregateLiterals: bool(opts, base, 'homogeneousAggregateLiterals'),
+    limits: createLimits(opts.limits, base.limits)
+  })
+}

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -39,11 +39,25 @@ const TOKEN = {
 export class ASTNode extends Array {
   #pos
   #input
-  constructor(pos, input, elements) {
-    super()
+  constructor(pos, input, elems) {
+    super(elems.length)
     this.#pos = pos
     this.#input = input
-    this.push(...elements)
+    /* eslint-disable no-fallthrough */
+    switch (elems.length) {
+      case 4:
+        this[3] = elems[3]
+      case 3:
+        this[2] = elems[2]
+      case 2:
+        this[1] = elems[1]
+      case 1:
+        this[0] = elems[0]
+        break
+      default:
+        throw new Error('Invalid number of elements for ASTNode')
+    }
+    /* eslint-enable no-fallthrough */
   }
 
   get input() {
@@ -449,10 +463,26 @@ class Lexer {
 }
 
 export class Parser {
-  constructor(input) {
+  constructor(input, limits) {
     this.input = input
     this.lexer = new Lexer(input)
     this.currentToken = this.lexer.nextToken()
+    this.limits = limits
+    this.maxDepthRemaining = limits.maxDepth
+    this.astNodesRemaining = limits.maxAstNodes
+  }
+
+  #limitExceeded(limitKey, source = this.currentToken) {
+    throw new ParseError(`Exceeded ${limitKey} (${this.limits[limitKey]})`, {
+      pos: source.pos,
+      input: this.input
+    })
+  }
+
+  #node(pos, elements) {
+    const node = new ASTNode(pos, this.input, elements)
+    if (!this.astNodesRemaining--) this.#limitExceeded('maxAstNodes', node)
+    return node
   }
 
   consume(expectedType) {
@@ -484,59 +514,55 @@ export class Parser {
 
   // Expression ::= LogicalOr ('?' Expression ':' Expression)?  // Made right-associative
   parseExpression() {
+    if (!this.maxDepthRemaining--) this.#limitExceeded('maxDepth')
     const expr = this.parseLogicalOr()
 
     if (this.match(TOKEN.QUESTION)) {
       const token = this.consume(TOKEN.QUESTION)
       const consequent = this.parseExpression()
       this.consume(TOKEN.COLON)
-      return new ASTNode(token.pos, this.input, ['?:', expr, consequent, this.parseExpression()])
+      const alternate = this.parseExpression()
+      this.maxDepthRemaining++
+      return this.#node(token.pos, ['?:', expr, consequent, alternate])
     }
-
+    this.maxDepthRemaining++
     return expr
   }
 
   // LogicalOr ::= LogicalAnd ('||' LogicalAnd)*
   parseLogicalOr() {
     let expr = this.parseLogicalAnd()
-
     while (this.match(TOKEN.OR)) {
       const token = this.consume(TOKEN.OR)
-      expr = new ASTNode(token.pos, this.input, [token.value, expr, this.parseLogicalAnd()])
+      expr = this.#node(token.pos, [token.value, expr, this.parseLogicalAnd()])
     }
-
     return expr
   }
 
   // LogicalAnd ::= Equality ('&&' Equality)*
   parseLogicalAnd() {
     let expr = this.parseEquality()
-
     while (this.match(TOKEN.AND)) {
       const token = this.consume(TOKEN.AND)
-      expr = new ASTNode(token.pos, this.input, [token.value, expr, this.parseEquality()])
+      expr = this.#node(token.pos, [token.value, expr, this.parseEquality()])
     }
-
     return expr
   }
 
   // Equality ::= Relational (('==' | '!=') Relational)*
   parseEquality() {
     let expr = this.parseRelational()
-
     while (this.match(TOKEN.EQ) || this.match(TOKEN.NE)) {
       const token = this.currentToken
       this.currentToken = this.lexer.nextToken()
-      expr = new ASTNode(token.pos, this.input, [token.value, expr, this.parseRelational()])
+      expr = this.#node(token.pos, [token.value, expr, this.parseRelational()])
     }
-
     return expr
   }
 
   // Relational ::= Additive (('<' | '<=' | '>' | '>=' | 'in') Additive)*
   parseRelational() {
     let expr = this.parseAdditive()
-
     while (
       this.match(TOKEN.LT) ||
       this.match(TOKEN.LE) ||
@@ -546,22 +572,19 @@ export class Parser {
     ) {
       const token = this.currentToken
       this.currentToken = this.lexer.nextToken()
-      expr = new ASTNode(token.pos, this.input, [token.value, expr, this.parseAdditive()])
+      expr = this.#node(token.pos, [token.value, expr, this.parseAdditive()])
     }
-
     return expr
   }
 
   // Additive ::= Multiplicative (('+' | '-') Multiplicative)*
   parseAdditive() {
     let expr = this.parseMultiplicative()
-
     while (this.match(TOKEN.PLUS) || this.match(TOKEN.MINUS)) {
       const token = this.currentToken
       this.currentToken = this.lexer.nextToken()
-      expr = new ASTNode(token.pos, this.input, [token.value, expr, this.parseMultiplicative()])
+      expr = this.#node(token.pos, [token.value, expr, this.parseMultiplicative()])
     }
-
     return expr
   }
 
@@ -572,7 +595,7 @@ export class Parser {
     while (this.match(TOKEN.MULTIPLY) || this.match(TOKEN.DIVIDE) || this.match(TOKEN.MODULO)) {
       const token = this.currentToken
       this.currentToken = this.lexer.nextToken()
-      expr = new ASTNode(token.pos, this.input, [token.value, expr, this.parseUnary()])
+      expr = this.#node(token.pos, [token.value, expr, this.parseUnary()])
     }
 
     return expr
@@ -583,14 +606,12 @@ export class Parser {
     const token = this.currentToken
     if (token.type === TOKEN.NOT) {
       this.currentToken = this.lexer.nextToken()
-      return new ASTNode(token.pos, this.input, ['!_', this.parseUnary()])
+      return this.#node(token.pos, ['!_', this.parseUnary()])
     }
-
     if (token.type === TOKEN.MINUS) {
       this.currentToken = this.lexer.nextToken()
-      return new ASTNode(token.pos, this.input, ['-_', this.parseUnary()])
+      return this.#node(token.pos, ['-_', this.parseUnary()])
     }
-
     return this.parsePostfix()
   }
 
@@ -605,10 +626,11 @@ export class Parser {
   // Postfix ::= Primary (('.' IDENTIFIER ('(' ArgumentList ')')? | '[' Expression ']'))*
   parsePostfix() {
     let expr = this.parsePrimary()
-
+    const depth = this.maxDepthRemaining
     while (true) {
       if (this.match(TOKEN.DOT)) {
-        this.consume(TOKEN.DOT)
+        const dot = this.consume(TOKEN.DOT)
+        if (!this.maxDepthRemaining--) this.#limitExceeded('maxDepth', dot)
         const property = this.consume(TOKEN.IDENTIFIER)
 
         // Check for method call
@@ -616,20 +638,21 @@ export class Parser {
           this.consume(TOKEN.LPAREN)
           const args = this.parseArgumentList()
           this.consume(TOKEN.RPAREN)
-          expr = new ASTNode(property.pos, this.input, ['rcall', property.value, expr, args])
+          expr = this.#node(property.pos, ['rcall', property.value, expr, args])
         } else {
-          expr = new ASTNode(property.pos, this.input, ['.', expr, property.value])
+          expr = this.#node(property.pos, ['.', expr, property.value])
         }
       } else if (this.match(TOKEN.LBRACKET)) {
         const token = this.consume(TOKEN.LBRACKET)
+        if (!this.maxDepthRemaining--) this.#limitExceeded('maxDepth', token)
         const index = this.parseExpression()
         this.consume(TOKEN.RBRACKET)
-        expr = new ASTNode(token.pos, this.input, ['[]', expr, index])
+        expr = this.#node(token.pos, ['[]', expr, index])
       } else {
         break
       }
     }
-
+    this.maxDepthRemaining = depth
     return expr
   }
 
@@ -638,23 +661,23 @@ export class Parser {
     switch (this.currentToken.type) {
       case TOKEN.NUMBER: {
         const token = this.consume(TOKEN.NUMBER)
-        return new ASTNode(token.pos, this.input, ['value', token.value])
+        return this.#node(token.pos, ['value', token.value])
       }
       case TOKEN.STRING: {
         const token = this.consume(TOKEN.STRING)
-        return new ASTNode(token.pos, this.input, ['value', token.value])
+        return this.#node(token.pos, ['value', token.value])
       }
       case TOKEN.BYTES: {
         const token = this.consume(TOKEN.BYTES)
-        return new ASTNode(token.pos, this.input, ['value', token.value])
+        return this.#node(token.pos, ['value', token.value])
       }
       case TOKEN.BOOLEAN: {
         const token = this.consume(TOKEN.BOOLEAN)
-        return new ASTNode(token.pos, this.input, ['value', token.value])
+        return this.#node(token.pos, ['value', token.value])
       }
       case TOKEN.NULL: {
         const token = this.consume(TOKEN.NULL)
-        return new ASTNode(token.pos, this.input, ['value', token.value])
+        return this.#node(token.pos, ['value', token.value])
       }
       case TOKEN.IDENTIFIER: {
         const identifier = this.consume(TOKEN.IDENTIFIER)
@@ -665,10 +688,10 @@ export class Parser {
           this.consume(TOKEN.LPAREN)
           const args = this.parseArgumentList()
           this.consume(TOKEN.RPAREN)
-          return new ASTNode(identifier.pos, this.input, ['call', identifier.value, args])
+          return this.#node(identifier.pos, ['call', identifier.value, args])
         }
 
-        return new ASTNode(identifier.pos, this.input, ['id', identifier.value])
+        return this.#node(identifier.pos, ['id', identifier.value])
       }
       case TOKEN.LPAREN: {
         this.consume(TOKEN.LPAREN)
@@ -691,38 +714,41 @@ export class Parser {
   parseList() {
     const token = this.consume(TOKEN.LBRACKET)
     const elements = []
+    let remainingElements = this.limits.maxListElements
 
     if (!this.match(TOKEN.RBRACKET)) {
       elements.push(this.parseExpression())
+      if (!remainingElements--) this.#limitExceeded('maxListElements', elements.at(-1))
       while (this.match(TOKEN.COMMA)) {
         this.consume(TOKEN.COMMA)
-        if (!this.match(TOKEN.RBRACKET)) {
-          elements.push(this.parseExpression())
-        }
+        if (this.match(TOKEN.RBRACKET)) break
+        elements.push(this.parseExpression())
+        if (!remainingElements--) this.#limitExceeded('maxListElements', elements.at(-1))
       }
     }
 
     this.consume(TOKEN.RBRACKET)
-    return new ASTNode(token.pos, this.input, ['list', elements])
+    return this.#node(token.pos, ['list', elements])
   }
 
   parseMap() {
     const token = this.consume(TOKEN.LBRACE)
-    const properties = []
+    const props = []
+    let remainingEntries = this.limits.maxMapEntries
 
     if (!this.match(TOKEN.RBRACE)) {
-      properties.push(this.parseProperty())
+      props.push(this.parseProperty())
+      if (!remainingEntries--) this.#limitExceeded('maxMapEntries', props.at(-1)[0])
       while (this.match(TOKEN.COMMA)) {
         this.consume(TOKEN.COMMA)
-        if (!this.match(TOKEN.RBRACE)) {
-          // Allow trailing comma
-          properties.push(this.parseProperty())
-        }
+        if (this.match(TOKEN.RBRACE)) break
+        props.push(this.parseProperty())
+        if (!remainingEntries--) this.#limitExceeded('maxMapEntries', props.at(-1)[0])
       }
     }
 
     this.consume(TOKEN.RBRACE)
-    return new ASTNode(token.pos, this.input, ['map', properties])
+    return this.#node(token.pos, ['map', props])
   }
 
   parseProperty() {
@@ -734,14 +760,16 @@ export class Parser {
 
   parseArgumentList() {
     const args = []
+    let remainingArgs = this.limits.maxCallArguments
 
     if (!this.match(TOKEN.RPAREN)) {
       args.push(this.parseExpression())
+      if (!remainingArgs--) this.#limitExceeded('maxCallArguments', args.at(-1))
       while (this.match(TOKEN.COMMA)) {
         this.consume(TOKEN.COMMA)
-        if (!this.match(TOKEN.RPAREN)) {
-          args.push(this.parseExpression())
-        }
+        if (this.match(TOKEN.RPAREN)) break
+        args.push(this.parseExpression())
+        if (!remainingArgs--) this.#limitExceeded('maxCallArguments', args.at(-1))
       }
     }
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -880,7 +880,7 @@ export class Registry {
       operatorDeclarations: this.#operatorDeclarations,
       functionDeclarations: this.#functionDeclarations,
       variables: this.variables,
-      unlistedVariablesAreDyn: opts?.unlistedVariablesAreDyn
+      unlistedVariablesAreDyn: opts.unlistedVariablesAreDyn
     })
   }
 

--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -9,14 +9,16 @@ import {TypeError, EvaluationError} from './errors.js'
  * - Property and index access validity
  */
 export class TypeChecker {
-  constructor(opts) {
-    this.ctx = opts.ctx
+  constructor(ctx, opts, isEvaluating) {
+    this.ctx = ctx
+
     this.objectTypes = opts.objectTypes
     this.objectTypesByConstructor = opts.objectTypesByConstructor
     this.registry = opts.registry
-    this.isEvaluating = opts.isEvaluating
-    this.homogeneousAggregateLiterals = opts.homogeneousAggregateLiterals
-    this.Error = opts.isEvaluating ? EvaluationError : TypeError
+    this.opts = opts.opts
+
+    this.isEvaluating = isEvaluating
+    this.Error = isEvaluating ? EvaluationError : TypeError
   }
 
   /**
@@ -29,14 +31,7 @@ export class TypeChecker {
   }
 
   createOverlay(varName, varType) {
-    return new this.constructor({
-      ctx: this.ctx.createOverlay(varName, varType),
-      objectTypes: this.objectTypes,
-      objectTypesByConstructor: this.objectTypesByConstructor,
-      registry: this.registry,
-      isEvaluating: this.isEvaluating,
-      homogeneousAggregateLiterals: this.homogeneousAggregateLiterals
-    })
+    return new this.constructor(this.ctx.createOverlay(varName, varType), this, this.isEvaluating)
   }
 
   /**
@@ -256,7 +251,7 @@ export class TypeChecker {
     if (arrLen === 0) return this.getType(`list`)
 
     let valueType = this.check(arr[0])
-    const check = this.homogeneousAggregateLiterals
+    const check = this.opts.homogeneousAggregateLiterals
       ? this.#checkElementHomogenous
       : this.#checkElement
 
@@ -269,7 +264,7 @@ export class TypeChecker {
     const arrLen = arr.length
     if (arrLen === 0) return this.getType('map')
 
-    const checkElement = this.homogeneousAggregateLiterals
+    const checkElement = this.opts.homogeneousAggregateLiterals
       ? this.#checkElementHomogenous
       : this.#checkElement
 

--- a/test/limits.test.js
+++ b/test/limits.test.js
@@ -1,0 +1,122 @@
+import {describe, test} from 'node:test'
+import {parse, expectParseThrows, assert, TestEnvironment} from './helpers.js'
+
+function populate(count, fn = (i) => i) {
+  return reduce(count, (a, i) => a.push(fn(i, a)) && a, [])
+}
+
+function reduce(count, fn = (_, i) => i, state) {
+  for (let i = 0; i < count; i++) state = fn(state, i)
+  return state
+}
+
+function buildMap(count) {
+  return `{${populate(count, (i) => `'k${i}': ${i}`).join(', ')}}`
+}
+
+function buildNestedList(count, varName = '') {
+  return reduce(count, (s) => `[${s}]`, varName)
+}
+
+function buildNestedMap(count) {
+  return reduce(count, (s, i) => `{ 'k${i}': ${s} }`, '0')
+}
+
+function buildSelectChain(count) {
+  return reduce(count, (s, i) => `${s}.a${i}`, 'a0')
+}
+
+function buildIndexChain(count) {
+  return reduce(count, (s, i) => `${s}[${i}]`, 'a')
+}
+
+function buildNestedCalls(count, varName = '') {
+  return reduce(count, (s, i) => `type(${s})`, varName)
+}
+
+describe('parser limits', () => {
+  test('allows call arguments up to default maxCallArguments', () => {
+    parse(`foo(${populate(32)})`)
+  })
+
+  test('throws when call arguments exceed maxCallArguments', () => {
+    expectParseThrows(`foo(${populate(33)})`, /maxCallArguments/)
+  })
+
+  test('allows up to default maxListElements', () => {
+    parse(`[${populate(1000)}]`)
+  })
+
+  test('throws when list elements exceed maxListElements', () => {
+    expectParseThrows(`[${populate(1001)}]`, /maxListElements/)
+  })
+
+  test('allows up to default maxMapEntries', () => {
+    parse(buildMap(1000))
+  })
+
+  test('throws when map entries exceed maxMapEntries', () => {
+    expectParseThrows(buildMap(1001), /maxMapEntries/)
+  })
+
+  test('allows aggregate nesting up to default maxDepth', () => {
+    parse(buildNestedList(249))
+    parse(buildNestedMap(249))
+  })
+
+  test('throws when aggregate nesting exceeds maxDepth', () => {
+    expectParseThrows(buildNestedList(251), /maxDepth/)
+    expectParseThrows(buildNestedMap(250), /maxDepth/)
+  })
+
+  test('allows select chains up to default maxDepth', () => {
+    // initial var and 11 .prop calls
+    parse(buildSelectChain(249))
+  })
+
+  test('throws when select depth exceeds maxDepth', () => {
+    expectParseThrows(buildSelectChain(250), /maxDepth/)
+  })
+
+  test('allows index chains up to default maxDepth', () => {
+    // initial var, 10 [] calls and the variable lookup within [var]
+    parse(buildIndexChain(248))
+  })
+
+  test('throws when index depth exceeds maxDepth', () => {
+    expectParseThrows(buildIndexChain(249), /maxDepth/)
+  })
+
+  test('allows nested function calls up to default maxDepth', () => {
+    parse(buildNestedCalls(250))
+  })
+
+  test('throws when nested function calls exceed maxDepth', () => {
+    expectParseThrows(buildNestedCalls(251), /maxDepth/)
+    expectParseThrows(buildNestedCalls(250, 'x'), /maxDepth/)
+  })
+
+  test('throws when AST nodes exceed configured maxAstNodes', () => {
+    const env = new TestEnvironment({
+      limits: {
+        maxCallArguments: 4,
+        maxListElements: 2,
+        maxMapEntries: 3,
+        maxDepth: 12,
+        maxAstNodes: 30
+      }
+    })
+
+    env.parse(populate(15).join(' + '))
+    assert.throws(() => env.parse(populate(16).join(' + ')), /maxAstNodes/)
+
+    env.parse(buildNestedCalls(12))
+    assert.throws(() => env.parse(buildNestedCalls(13)), /maxDepth/)
+
+    env.parse(`foo(${populate(4)})`)
+    assert.throws(() => env.parse(`foo(${populate(5)})`), /maxCallArguments/)
+
+    env.parse(`[${populate(2)}]`)
+    assert.throws(() => env.parse(`[${populate(3)}]`), /maxListElements/)
+  })
+})

--- a/test/unary-operators.test.js
+++ b/test/unary-operators.test.js
@@ -70,5 +70,8 @@ describe('unary operators', () => {
     test('should handle complex unary expressions', () => expectEval('!!!(false || true)', false))
   })
 
-  test('supports many repetitions', () => expectEval(' + 1'.repeat(40).replace(' + ', ''), 40n))
+  test('supports many repetitions', () => {
+    const expression = Array.from({length: 32}, () => '1').join(' + ')
+    expectEval(expression, 32n)
+  })
 })


### PR DESCRIPTION
### Changelog
- 🎁 Added a `limits` option to `Environment` supported when creating new environments or clones.
  Uses sensible defaults (`maxAstNodes=100k`, `maxDepth=250`, `maxListElements=1000`, `maxMapEntries=1000`, `maxCallArguments=32`)
