### PR TITLE
Support optional chaining

### DIFF
--- a/lib/evaluator.d.ts
+++ b/lib/evaluator.d.ts
@@ -1,4 +1,4 @@
 export * from './index.js'
 
 // Re-export Duration and UnsignedInt from functions.js
-export {Duration, UnsignedInt, Type, TYPES} from './functions.js'
+export {Duration, UnsignedInt} from './functions.js'

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -1,4 +1,4 @@
-import {TYPES, celTypes, createRegistry, RootContext} from './registry.js'
+import {celTypes, createRegistry, RootContext} from './registry.js'
 import {EvaluationError} from './errors.js'
 import {registerFunctions, Duration, UnsignedInt} from './functions.js'
 import {registerMacros} from './macros.js'
@@ -7,9 +7,9 @@ import {TypeChecker} from './type-checker.js'
 import {Parser} from './parser.js'
 import {createOptions} from './options.js'
 
-const globalRegistry = createRegistry()
-registerOverloads(globalRegistry)
+const globalRegistry = createRegistry({enableOptionalTypes: false})
 registerFunctions(globalRegistry)
+registerOverloads(globalRegistry)
 registerMacros(globalRegistry)
 
 function handleId(ast, ev, ctx) {
@@ -103,17 +103,11 @@ function handleUnary(ast, ev, left) {
 }
 
 function handleBinary(ast, ev, left, right) {
-  const leftType = getOperandType(ast[1].checkedType, left, ev)
-  const rightType = getOperandType(ast[2].checkedType, right, ev)
+  const leftType = ev.debugOperandType(left, ast[1].checkedType)
+  const rightType = ev.debugOperandType(right, ast[2].checkedType)
   const overload = ev.registry.findBinaryOverload(ast[0], leftType, rightType)
   if (overload) return overload.handler(left, right, ast, ev)
   throw new EvaluationError(`no such overload: ${leftType} ${ast[0]} ${rightType}`, ast)
-}
-
-function getOperandType(checkedType, value, ev) {
-  if (!checkedType) return ev.debugRuntimeType(value, checkedType)
-  if (checkedType.hasNoDynTypes()) return checkedType
-  return ev.registry.getDynType(ev.debugRuntimeType(value, checkedType))
 }
 
 function _call(ast, ev, args) {
@@ -132,12 +126,14 @@ function _call(ast, ev, args) {
 
   const types = (ast.types ??= new Array(argLen))
   let i = argLen
-  while (i--) types[i] = ev.debugRuntimeType(args[i], argAst[i].checkedType)
+  while (i--) types[i] = ev.debugOperandType(args[i], argAst[i].checkedType)
 
-  const decl = functionCandidates.filterByReceiverType(null).findMatch(types)
+  const decl = functionCandidates.findMatch(types, null, ev.registry)
   if (decl) return decl.handler.apply(ev, args)
   throw new EvaluationError(
-    `found no matching overload for '${functionName}(${types.join(', ')})'`,
+    `found no matching overload for '${functionName}(${types
+      .map((t) => t.unwrappedType)
+      .join(', ')})'`,
     ast
   )
 }
@@ -160,13 +156,15 @@ function _receiverCall(ast, ev, receiver, args) {
 
   let i = args.length
   const types = (ast.argTypes ??= new Array(i))
-  while (i--) types[i] = ev.debugRuntimeType(args[i], argAst[i].checkedType)
+  while (i--) types[i] = ev.debugOperandType(args[i], argAst[i].checkedType)
 
-  const decl = functionCandidates.filterByReceiverType(receiverType).findMatch(types)
+  const decl = functionCandidates.findMatch(types, receiverType, ev.registry)
   if (decl) return decl.handler.call(ev, receiver, ...args)
 
   throw new EvaluationError(
-    `found no matching overload for '${receiverType.type}.${functionName}(${types.join(', ')})'`,
+    `found no matching overload for '${receiverType.type}.${functionName}(${types
+      .map((t) => t.unwrappedType)
+      .join(', ')})'`,
     ast
   )
 }
@@ -214,12 +212,15 @@ function withPromise(ast, ev, a, b, fn) {
   return fn(ast, ev, a, b)
 }
 
+function oFieldAccess(ast, ev, left, right) {
+  return celTypes.optional.field(left, right, ast, ev)
+}
+
 function fieldAccess(ast, ev, left, right) {
   return ev.debugType(left).field(left, right, ast, ev)
 }
 
 const registryByEnvironment = new WeakMap()
-const globalValues = new Map(Object.entries(TYPES))
 
 class Environment {
   #registry
@@ -242,11 +243,11 @@ class Environment {
       opts: this.opts
     }
 
-    this.#rootContext = new RootContext(this.#registry.variables, globalValues)
     this.#typeChecker = new TypeChecker(childOpts)
     this.#evalTypeChecker = new TypeChecker(childOpts, true)
     this.#evaluator = new Evaluator(childOpts)
     this.#parser = new Parser(this.opts.limits, this.#registry)
+    this.#rootContext = new RootContext(this.#registry.variables, this.#registry.constants)
     registryByEnvironment.set(this, this.#registry)
     Object.freeze(this)
   }
@@ -272,6 +273,11 @@ class Environment {
 
   registerVariable(name, type) {
     this.#registry.registerVariable(name, type)
+    return this
+  }
+
+  registerConstant(name, type, value) {
+    this.#registry.registerConstant(name, type, value)
     return this
   }
 
@@ -381,6 +387,11 @@ class Evaluator {
     )
   }
 
+  debugOperandType(value, checkedType) {
+    if (checkedType?.hasNoDynTypes()) return checkedType
+    return this.registry.getDynType(this.debugRuntimeType(value, checkedType))
+  }
+
   debugRuntimeType(value, checkedType) {
     if (checkedType?.hasNoDynTypes()) return checkedType
 
@@ -417,8 +428,12 @@ class Evaluator {
         return handleLogicalAnd(ast, this, ctx)
       case '.':
         return withPromise(ast, this, this.eval(ast[1], ctx), ast[2], fieldAccess)
+      case '.?':
+        return withPromise(ast, this, this.eval(ast[1], ctx), ast[2], oFieldAccess)
       case '[]':
         return withPromise(ast, this, this.eval(ast[1], ctx), this.eval(ast[2], ctx), fieldAccess)
+      case '[?]':
+        return withPromise(ast, this, this.eval(ast[1], ctx), this.eval(ast[2], ctx), oFieldAccess)
       case 'rcall':
         return handleReceiverCall(ast, this, ctx)
       case 'call':

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,5 +1,6 @@
 import {EvaluationError} from './errors.js'
 import {TYPES, Type} from './registry.js'
+import {Optional} from './optional.js'
 
 export class UnsignedInt {
   #value
@@ -129,11 +130,28 @@ export class Duration {
   }
 }
 
+class OptionalNamespace {}
+const optionalNamespace = new OptionalNamespace()
+
+export function toggleOptionalTypes(registry, enable) {
+  registry.constants.set('optional', enable ? optionalNamespace : undefined)
+}
+
 export function registerFunctions(registry) {
   const functionOverload = (sig, handler) => registry.registerFunctionOverload(sig, handler)
   const identity = (v) => v
 
   functionOverload('dyn(dyn): dyn', identity)
+
+  const optionalConstant = registry.enableOptionalTypes ? optionalNamespace : undefined
+  registry.registerType('OptionalNamespace', OptionalNamespace)
+  registry.registerConstant('optional', 'OptionalNamespace', optionalConstant)
+  functionOverload('optional.hasValue(): bool', (v) => v.hasValue())
+  functionOverload('optional<A>.value(): A', (v) => v.value())
+  functionOverload('optional<A>.orValue(A): A', (v, orValue) => v.orValue(orValue))
+  functionOverload('optional<A>.or(A): optional<A>', (v, orValue) => v.or(orValue))
+  functionOverload('OptionalNamespace.of(A): optional<A>', (_, value) => Optional.of(value))
+  functionOverload('OptionalNamespace.none(): optional', () => Optional.none())
 
   for (const _t in TYPES) {
     const type = TYPES[_t]
@@ -385,6 +403,13 @@ export function registerFunctions(registry) {
   })
 
   const TS = 'google.protobuf.Timestamp'
+  const GPD = 'google.protobuf.Duration'
+  const TimestampType = registry.registerType(TS, Date).getObjectType(TS).typeType
+  const DurationType = registry.registerType(GPD, Duration).getObjectType(GPD).typeType
+  registry.registerConstant('google', 'map<string, map<string, type>>', {
+    protobuf: {Duration: DurationType, Timestamp: TimestampType}
+  })
+
   function tzDate(d, timeZone) {
     return new Date(d.toLocaleString('en-US', {timeZone}))
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -164,6 +164,10 @@ export interface EnvironmentOptions {
    * When false, mixed literals are inferred as list<dyn> or map with dyn components.
    */
   homogeneousAggregateLiterals?: boolean
+  /**
+   * Enable experimental optional types (.?/.[]? chaining and optional.* helpers). Disabled by default.
+   */
+  enableOptionalTypes?: boolean
   /** Optional overrides for parser/evaluator structural limits */
   limits?: Partial<Limits>
 }
@@ -219,6 +223,22 @@ export class Environment {
    * ```
    */
   registerVariable(name: string, type: string): this
+
+  /**
+   * Register a constant value that is always available in expressions without providing it via context.
+   *
+   * @param name - The constant identifier exposed to CEL expressions
+   * @param type - The CEL type name of the constant (e.g., 'int', 'string')
+   * @param value - The concrete value supplied during registration
+   * @returns This environment for chaining further registrations
+   *
+   * @example
+   * ```typescript
+   * const env = new Environment().registerConstant('timezone', 'string', 'UTC')
+   * env.evaluate('timezone == "UTC"') // true
+   * ```
+   */
+  registerConstant(name: string, type: string, value: any): this
 
   /**
    * Register a custom function or method.

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -254,10 +254,14 @@ function createHasExpander() {
     const nodes = macro.macroHasProps
     let i = nodes.length
     let obj = ev.eval(nodes[--i], ctx)
+    let inOptionalContext
     while (i--) {
       const node = nodes[i]
+      if (node[0] === '.?') inOptionalContext ??= true
       obj = ev.debugType(obj).fieldLazy(obj, node[2], node, ev)
-      if (i && obj === undefined) throw new EvaluationError(`No such key: ${node[2]}`, node)
+      if (obj !== undefined) continue
+      if (!(!inOptionalContext && i && node[0] === '.')) break
+      throw new EvaluationError(`No such key: ${node[2]}`, node)
     }
     return obj !== undefined
   }
@@ -267,7 +271,7 @@ function createHasExpander() {
     if (node[0] !== '.') throw new checker.Error(invalidHasArgument, node)
     if (!macro.macroHasProps) {
       const props = []
-      while (node[0] === '.' && props.push(node)) node = node[1]
+      while ((node[0] === '.' || node[0] === '.?') && props.push(node)) node = node[1]
       if (node[0] !== 'id') throw new checker.Error(invalidHasArgument, node)
       props.push(node)
       macro.macroHasProps = props

--- a/lib/optional.js
+++ b/lib/optional.js
@@ -1,0 +1,47 @@
+import {EvaluationError} from './errors.js'
+
+export class Optional {
+  #value
+
+  constructor(value) {
+    this.#value = value
+  }
+
+  static of(value) {
+    if (value === undefined) return OPTIONAL_NONE
+    return new Optional(value)
+  }
+
+  static none() {
+    return OPTIONAL_NONE
+  }
+
+  hasValue() {
+    return this.#value !== undefined
+  }
+
+  value() {
+    if (this.#value === undefined) throw new EvaluationError('Optional value is not present')
+    return this.#value
+  }
+
+  or(defaultValue) {
+    return this.#value === undefined ? new Optional(defaultValue) : this
+  }
+
+  orValue(defaultValue) {
+    return this.#value === undefined ? defaultValue : this.#value
+  }
+
+  get [Symbol.toStringTag]() {
+    return 'optional'
+  }
+
+  [Symbol.for('nodejs.util.inspect.custom')]() {
+    return this.#value === undefined
+      ? `Optional { none }`
+      : `Optional { value: ${JSON.stringify(this.#value)} }`
+  }
+}
+
+export const OPTIONAL_NONE = Object.freeze(new Optional())

--- a/lib/options.js
+++ b/lib/options.js
@@ -24,6 +24,7 @@ function createLimits(overrides, base = DEFAULT_LIMITS) {
 const DEFAULT_OPTIONS = Object.freeze({
   unlistedVariablesAreDyn: false,
   homogeneousAggregateLiterals: true,
+  enableOptionalTypes: false,
   limits: DEFAULT_LIMITS
 })
 
@@ -38,6 +39,7 @@ export function createOptions(opts, base = DEFAULT_OPTIONS) {
   return Object.freeze({
     unlistedVariablesAreDyn: bool(opts, base, 'unlistedVariablesAreDyn'),
     homogeneousAggregateLiterals: bool(opts, base, 'homogeneousAggregateLiterals'),
+    enableOptionalTypes: bool(opts, base, 'enableOptionalTypes'),
     limits: createLimits(opts.limits, base.limits)
   })
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -150,7 +150,6 @@ class Lexer {
         case '*':
           return {type: TOKEN.MULTIPLY, value: '*', pos: this.pos++}
         case '/':
-          // Skip comment
           if (input[pos + 1] === '/') {
             while (this.pos < length && this.input[this.pos] !== '\n') this.pos++
             continue
@@ -495,7 +494,7 @@ export class Parser {
     return ast
   }
 
-  // Expression ::= LogicalOr ('?' Expression ':' Expression)?  // Made right-associative
+  // Expression ::= LogicalOr ('?' Expression ':' Expression)?
   parseExpression() {
     if (!this.maxDepthRemaining--) this.#limitExceeded('maxDepth')
     const expr = this.parseLogicalOr()
@@ -592,9 +591,12 @@ export class Parser {
       if (this.match(TOKEN.DOT)) {
         const dot = this.#advanceToken()
         if (!this.maxDepthRemaining--) this.#limitExceeded('maxDepth', dot)
+
+        const isOptionalChain =
+          this.match(TOKEN.QUESTION) && this.registry.enableOptionalTypes && !!this.#advanceToken()
+
         const property = this.consume(TOKEN.IDENTIFIER)
 
-        // Check for method call
         if (this.match(TOKEN.LPAREN) && this.#advanceToken()) {
           const args = this.parseArgumentList()
           this.consume(TOKEN.RPAREN)
@@ -602,7 +604,7 @@ export class Parser {
             this.#node(property.pos, ['rcall', property.value, expr, args])
           )
         } else {
-          expr = this.#node(property.pos, ['.', expr, property.value])
+          expr = this.#node(property.pos, [isOptionalChain ? '.?' : '.', expr, property.value])
         }
         continue
       }
@@ -610,9 +612,13 @@ export class Parser {
       if (this.match(TOKEN.LBRACKET)) {
         const bracket = this.#advanceToken()
         if (!this.maxDepthRemaining--) this.#limitExceeded('maxDepth', bracket)
+
+        const isOptionalChain =
+          this.match(TOKEN.QUESTION) && this.registry.enableOptionalTypes && !!this.#advanceToken()
+
         const index = this.parseExpression()
         this.consume(TOKEN.RBRACKET)
-        expr = this.#node(bracket.pos, ['[]', expr, index])
+        expr = this.#node(bracket.pos, [isOptionalChain ? '[?]' : '[]', expr, index])
         continue
       }
       break

--- a/lib/registry.d.ts
+++ b/lib/registry.d.ts
@@ -71,14 +71,6 @@ export const TYPES: {
   bytes: Type
   null_type: Type
   type: Type
-  google: {
-    protobuf: {
-      Timestamp: Type
-      Duration: Type
-    }
-  }
-  'google.protobuf.Timestamp': Type
-  'google.protobuf.Duration': Type
 }
 
 /**
@@ -94,8 +86,6 @@ export const celTypes: {
   dyn: TypeDeclaration
   null: TypeDeclaration
   type: TypeDeclaration
-  'google.protobuf.Timestamp': TypeDeclaration
-  'google.protobuf.Duration': TypeDeclaration
   list: TypeDeclaration
   'list<dyn>': TypeDeclaration
   map: TypeDeclaration
@@ -189,7 +179,7 @@ export class Registry {
    * Clone this registry to create a new isolated instance.
    * @returns A new registry with a deep copy of all registrations
    */
-  clone(opts?: {unlistedVariablesAreDyn?: boolean}): Registry
+  clone(opts?: {unlistedVariablesAreDyn?: boolean; enableOptionalTypes?: boolean}): Registry
 
   /** Registered object types keyed by CEL typename. */
   readonly objectTypes: Map<string, any>
@@ -202,6 +192,9 @@ export class Registry {
 
   /** Registered variables and their type declarations. */
   readonly variables: Map<string, TypeDeclaration>
+
+  /** Whether optional types/functions are enabled for this registry. */
+  readonly enableOptionalTypes: boolean
 }
 
 /**
@@ -216,6 +209,7 @@ export interface RegistryOptions {
   typeDeclarations?: Map<string, TypeDeclaration>
   variables?: Map<string, TypeDeclaration>
   unlistedVariablesAreDyn?: boolean
+  enableOptionalTypes?: boolean
 }
 
 /**

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,5 +1,6 @@
 import {EvaluationError} from './errors.js'
-import {Duration, UnsignedInt} from './functions.js'
+import {UnsignedInt, toggleOptionalTypes} from './functions.js'
+import {Optional, OPTIONAL_NONE} from './optional.js'
 
 export class Type {
   #name
@@ -31,17 +32,8 @@ export const TYPES = {
   list: new Type('list'),
   bytes: new Type('bytes'),
   null_type: new Type('null'),
-  type: new Type('type'),
-  google: {
-    protobuf: {
-      Timestamp: new Type('google.protobuf.Timestamp'),
-      Duration: new Type('google.protobuf.Duration')
-    }
-  }
+  type: new Type('type')
 }
-
-TYPES['google.protobuf.Timestamp'] = TYPES.google.protobuf.Timestamp
-TYPES['google.protobuf.Duration'] = TYPES.google.protobuf.Duration
 
 class LayeredMap {
   #parent = null
@@ -127,6 +119,7 @@ export class TypeDeclaration {
     else if (kind === 'map') this.fieldLazy = this.#getMapField
     else if (kind === 'message') this.fieldLazy = this.#getMessageField
     else if (kind === 'dyn') this.fieldLazy = this.#getMapField
+    else if (kind === 'optional') this.fieldLazy = this.#getOptionalField
 
     Object.freeze(this)
   }
@@ -164,6 +157,8 @@ export class TypeDeclaration {
         return `map<${this.keyType.templated(bindings)}, ${this.valueType.templated(bindings)}>`
       case 'list':
         return `list<${this.valueType.templated(bindings)}>`
+      case 'optional':
+        return `optional<${this.valueType.templated(bindings)}>`
       default:
         return this.name
     }
@@ -171,6 +166,19 @@ export class TypeDeclaration {
 
   toString() {
     return this.name
+  }
+
+  #getOptionalField(obj, key, ast, ev) {
+    obj = obj instanceof Optional ? obj.orValue() : obj
+    if (obj === undefined) return OPTIONAL_NONE
+
+    const type = ev.debugType(obj)
+    try {
+      return Optional.of(type.fieldLazy(obj, key, ast, ev))
+    } catch (e) {
+      if (e instanceof EvaluationError) return OPTIONAL_NONE
+      throw e
+    }
   }
 
   #getMessageField(obj, key, ast, ev) {
@@ -263,6 +271,12 @@ export class TypeDeclaration {
         return o.kind === 'list' && s.valueType.matches(o.valueType)
       case 'map':
         return o.kind === 'map' && s.keyType.matches(o.keyType) && s.valueType.matches(o.valueType)
+      case 'optional':
+        // optional<T> matches optional and optional<U> if T matches U
+        return (
+          o.kind === 'optional' &&
+          (!s.valueType || !o.valueType || s.valueType.matches(o.valueType))
+        )
       default:
         return s.name === o.name
     }
@@ -281,6 +295,7 @@ function wrapMacroExpander(name, handler) {
 }
 
 export class FunctionDeclaration {
+  #hasPlaceholderTypes
   constructor({name, receiverType, argTypes, returnType, handler}) {
     this.name = name
     this.receiverType = receiverType || null
@@ -295,9 +310,19 @@ export class FunctionDeclaration {
     Object.freeze(this)
   }
 
+  hasPlaceholder() {
+    return (this.#hasPlaceholderTypes ??=
+      this.returnType.hasPlaceholder() ||
+      this.receiverType?.hasPlaceholder() ||
+      this.argTypes.some((t) => t.hasPlaceholder()) ||
+      false)
+  }
+
   matchesArgs(argTypes) {
-    if (argTypes.length !== this.argTypes.length) return false
-    return this.argTypes.every((t, i) => t.matches(argTypes[i]))
+    return argTypes.length === this.argTypes.length &&
+      this.argTypes.every((t, i) => t.matches(argTypes[i]))
+      ? this
+      : null
   }
 }
 
@@ -352,6 +377,11 @@ function _createDynType(valueType) {
   return new TypeDeclaration({kind: 'dyn', name, type: name, valueType})
 }
 
+function _createOptionalType(valueType) {
+  const name = valueType ? `optional<${valueType}>` : 'optional'
+  return new TypeDeclaration({kind: 'optional', name, type: 'optional', valueType})
+}
+
 function _createMapType(keyType, valueType) {
   return new TypeDeclaration({
     kind: 'map',
@@ -382,65 +412,102 @@ export const celTypes = Object.freeze({
   dyn: dynType,
   null: _createPrimitiveType('null'),
   type: _createPrimitiveType('type'),
-  'google.protobuf.Timestamp': _createPrimitiveType('google.protobuf.Timestamp'),
-  'google.protobuf.Duration': _createPrimitiveType('google.protobuf.Duration'),
+  optional: _createOptionalType(dynType),
   list: listType,
   'list<dyn>': listType,
   map: mapType,
   'map<dyn, dyn>': mapType
 })
 
-class FunctionsByReceiver {
-  /** @type {Array<FunctionDeclaration>} */
-  functions = []
-  exists = false
+const AGGREGATE_RECEIVER_TYPES = new Set(['list', 'map', 'optional'])
 
-  add(decl) {
-    this.exists = true
-    this.functions.push(decl)
-  }
-
-  findMatch(argTypes) {
-    if (!this.exists) return null
-    for (const fn of this.functions) if (fn.matchesArgs(argTypes)) return fn
-    return null
-  }
-}
-
-const NO_RECEIVER = new FunctionsByReceiver()
 class FunctionCandidates {
   exists = false
   returnType = null
-  /** @type {Map<string|null, FunctionsByReceiver>} */
+  /** @type {Map<TypeDeclaration|null, Array<FunctionDeclaration>>} */
   #byReceiverType = new Map()
 
   add(declaration) {
     this.exists = true
-
     if (!this.returnType) this.returnType = declaration.returnType
     else if (this.returnType !== declaration.returnType) this.returnType = dynType
 
     const receiverType = declaration.receiverType
-    const coll =
-      this.#byReceiverType.get(receiverType) ||
-      this.#byReceiverType.set(receiverType, new FunctionsByReceiver()).get(receiverType)
-
-    coll.add(declaration)
+    const functions = this.#byReceiverType.get(receiverType)
+    if (functions) functions.push(declaration)
+    else this.#byReceiverType.set(receiverType, [declaration])
   }
 
-  filterByReceiverType(receiverType) {
-    if (receiverType === null) return this.#byReceiverType.get(null) || NO_RECEIVER
-
-    return (
-      // First try exact match
-      this.#byReceiverType.get(receiverType) ||
-      // For generic types, also try matching with the base type
-      // e.g., if looking for list<string>, also check list<dyn>
-      (receiverType.type === 'list' || receiverType.type === 'map'
-        ? this.#byReceiverType.get(celTypes[receiverType.type])
-        : null) ||
-      NO_RECEIVER
+  findMatch(argTypes, receiverType, registry) {
+    // Try exact receiver type match
+    let match = this.#findInFunctions(
+      this.#byReceiverType.get(receiverType),
+      argTypes,
+      receiverType,
+      registry
     )
+    if (match) return match
+
+    // Try aggregate base type (e.g., list<int> -> list)
+    if (receiverType && AGGREGATE_RECEIVER_TYPES.has(receiverType.type)) {
+      match = this.#findInFunctions(
+        this.#byReceiverType.get(celTypes[receiverType.type]),
+        argTypes,
+        receiverType,
+        registry
+      )
+      if (match) return match
+    }
+
+    // Try placeholder receiver types
+    for (const [key, funcs] of this.#byReceiverType) {
+      if (key?.hasPlaceholder?.()) {
+        match = this.#findInFunctions(funcs, argTypes, receiverType, registry)
+        if (match) return match
+      }
+    }
+
+    return null
+  }
+
+  #findInFunctions(functions, argTypes, receiverType, registry) {
+    if (!functions) return null
+
+    let fn
+    let match
+    for (let i = 0; i < functions.length; i++) {
+      fn = functions[i]
+      if (fn.hasPlaceholder()) {
+        match = this.#matchWithPlaceholders(fn, argTypes, receiverType, registry)
+        if (match) return match
+        else continue
+      }
+
+      if (receiverType && fn.receiverType && !receiverType.matches(fn.receiverType)) continue
+      if ((match = fn.matchesArgs(argTypes))) return match
+    }
+    return null
+  }
+
+  #matchWithPlaceholders(fn, argTypes, receiverType, registry) {
+    const bindings = new Map()
+    if (receiverType && fn.receiverType) {
+      if (!registry.matchTypeWithPlaceholders(fn.receiverType, receiverType, bindings)) {
+        return null
+      }
+    }
+
+    for (let i = 0; i < argTypes.length; i++) {
+      if (!registry.matchTypeWithPlaceholders(fn.argTypes[i], argTypes[i], bindings)) {
+        return null
+      }
+    }
+
+    return {
+      handler: fn.handler,
+      signature: fn.signature,
+      returnType: registry.getType(fn.returnType.templated(bindings))
+    }
   }
 }
 
@@ -471,10 +538,9 @@ const builtinObjectTypes = [
   [Map, 'map'],
   [Array, 'list'],
   [Uint8Array, 'bytes'],
-  [Date, 'google.protobuf.Timestamp'],
-  [Duration, 'google.protobuf.Duration'],
   [UnsignedInt, 'uint'],
-  [Type, 'type']
+  [Type, 'type'],
+  [Optional, 'optional']
 ]
 
 if (typeof Buffer !== 'undefined') builtinObjectTypes.push([Buffer, 'bytes'])
@@ -488,8 +554,10 @@ export class Registry {
   #dynTypes = new Map()
   #listTypes = new Map()
   #mapTypes = new Map()
+  #optionalTypes = new Map()
 
   constructor(opts = {}) {
+    this.enableOptionalTypes = opts.enableOptionalTypes ?? false
     this.objectTypes = createLayeredMap(opts.objectTypes)
     this.objectTypesByConstructor = createLayeredMap(opts.objectTypesByConstructor)
     this.objectTypeInstances = createLayeredMap(opts.objectTypeInstances)
@@ -500,20 +568,17 @@ export class Registry {
       undefined,
       false
     )
+
+    this.constants = createLayeredMap(opts.constants)
     this.variables = opts.unlistedVariablesAreDyn
       ? createLayeredMap(opts.variables, DynVariableRegistry)
       : createLayeredMap(opts.variables)
 
     if (!this.variables.size) {
-      for (const [instance, name] of builtinObjectTypes) {
-        this.registerType(name, instance, true)
-      }
-
-      const globalValues = new Map(Object.entries(TYPES))
-      for (const [name, type] of globalValues) {
-        if (!(type instanceof Type)) continue
-        this.registerVariable(name, 'type')
-      }
+      for (const t of builtinObjectTypes) this.registerType(t[1], t[0], true)
+      for (const n in TYPES) this.registerConstant(n, 'type', TYPES[n])
+    } else {
+      toggleOptionalTypes(this, this.enableOptionalTypes)
     }
   }
 
@@ -528,6 +593,12 @@ export class Registry {
     return this
   }
 
+  registerConstant(name, type, value) {
+    this.registerVariable(name, type)
+    this.constants.set(name, value)
+    return this
+  }
+
   getFunctionCandidates(receiverType, functionName, argCount) {
     const candidates = new FunctionCandidates()
     for (const [, dec] of this.#functionDeclarations) {
@@ -537,7 +608,11 @@ export class Registry {
 
       candidates.exists = true
 
-      if (receiverType && !receiverType.matches(dec.receiverType)) continue
+      // For functions with placeholder types in receiver, skip the simple match check
+      // as we'll do proper placeholder matching later in findMatch()
+      if (receiverType && !dec.receiverType.hasPlaceholder()) {
+        if (!receiverType.matches(dec.receiverType)) continue
+      }
 
       // Only add to candidates if arg count matches
       if (dec.argTypes.length !== argCount) continue
@@ -573,6 +648,13 @@ export class Registry {
     )
   }
 
+  getOptionalType(type) {
+    return (
+      this.#optionalTypes.get(type) ||
+      this.#optionalTypes.set(type, this.#parseTypeString(`optional<${type}>`, true)).get(type)
+    )
+  }
+
   assertType(typename, type, signature) {
     try {
       return this.#parseTypeString(typename, true)
@@ -594,6 +676,7 @@ export class Registry {
 
     const decl = {
       name: typename,
+      typeType: TYPES[typename] || new Type(typename),
       type: this.#parseTypeString(typename, false),
       ctor: typeof _d === 'function' ? _d : _d?.ctor,
       fields: this.#normalizeFields(typename, _d?.fields)
@@ -609,42 +692,51 @@ export class Registry {
 
     this.objectTypes.set(typename, decl)
     this.objectTypesByConstructor.set(decl.ctor, decl)
-    if (withoutDynRegistration) return
+    if (withoutDynRegistration) return this
 
-    const type = new Type(typename)
-    this.objectTypeInstances.set(typename, type)
-    this.registerFunctionOverload(`type(${typename}): type`, () => type)
+    this.objectTypeInstances.set(typename, decl.typeType)
+    this.registerFunctionOverload(`type(${typename}): type`, () => decl.typeType)
+    return this
+  }
+
+  getObjectType(name) {
+    return this.objectTypes.get(name)
   }
 
   /** @returns {TypeDeclaration} */
   #parseTypeString(typeStr, requireKnownTypes = false) {
-    const existing = this.#typeDeclarations.get(typeStr)
-    if (existing) return existing
+    let match = this.#typeDeclarations.get(typeStr)
+    if (match) return match
 
-    const paramMatch = typeStr.match(/^[A-Z]$/)
-    if (paramMatch) return this.#createDeclaration(_createPlaceholderType, typeStr, typeStr)
+    match = typeStr.match(/^[A-Z]$/)
+    if (match) return this.#createDeclaration(_createPlaceholderType, typeStr, typeStr)
 
-    // Handle dyn<type> patterns used for dynamic overloads
-    const dynMatch = typeStr.match(/^dyn<(.+)>$/)
-    if (dynMatch) {
-      const type = this.#parseTypeString(dynMatch[1].trim(), requireKnownTypes)
+    match = typeStr.match(/^dyn<(.+)>$/)
+    if (match) {
+      const type = this.#parseTypeString(match[1].trim(), requireKnownTypes)
       return this.#createDeclaration(_createDynType, `dyn<${type}>`, type)
     }
 
-    const listMatch = typeStr.match(/^list<(.+)>$/)
-    if (listMatch) {
-      const vType = this.#parseTypeString(listMatch[1].trim(), requireKnownTypes)
+    match = typeStr.match(/^list<(.+)>$/)
+    if (match) {
+      const vType = this.#parseTypeString(match[1].trim(), requireKnownTypes)
       return this.#createDeclaration(_createListType, `list<${vType}>`, vType)
     }
 
-    const mapMatch = typeStr.match(/^map<(.+)>$/)
-    if (mapMatch) {
-      const parts = splitByComma(mapMatch[1])
+    match = typeStr.match(/^map<(.+)>$/)
+    if (match) {
+      const parts = splitByComma(match[1])
       if (parts.length !== 2) throw new Error(`Invalid map type: ${typeStr}`)
 
       const kType = this.#parseTypeString(parts[0].trim(), requireKnownTypes)
       const vType = this.#parseTypeString(parts[1].trim(), requireKnownTypes)
       return this.#createDeclaration(_createMapType, `map<${kType}, ${vType}>`, kType, vType)
+    }
+
+    match = typeStr.match(/^optional<(.+)>$/)
+    if (match) {
+      const vType = this.#parseTypeString(match[1].trim(), requireKnownTypes)
+      return this.#createDeclaration(_createOptionalType, `optional<${vType}>`, vType)
     }
 
     if (requireKnownTypes) {
@@ -778,10 +870,10 @@ export class Registry {
 
   #matchesOverload(decl, actualLeft, actualRight) {
     const bindings = decl.hasPlaceholder() ? new Map() : null
-    const leftType = this.#matchTypeWithPlaceholders(decl.leftType, actualLeft, bindings)
+    const leftType = this.matchTypeWithPlaceholders(decl.leftType, actualLeft, bindings)
     if (!leftType) return
 
-    const rightType = this.#matchTypeWithPlaceholders(decl.rightType, actualRight, bindings)
+    const rightType = this.matchTypeWithPlaceholders(decl.rightType, actualRight, bindings)
     if (!rightType) return
 
     if ((decl.operator === '==' || decl.operator === '!=') && !leftType.matchesBoth(rightType))
@@ -797,55 +889,74 @@ export class Registry {
       : decl
   }
 
-  #matchTypeWithPlaceholders(declared, actual, bindings) {
+  matchTypeWithPlaceholders(declared, actual, bindings) {
     if (!declared.hasPlaceholder()) return actual.matches(declared) ? actual : null
 
     const treatAsDyn = actual.kind === 'dyn'
     if (!this.#collectPlaceholderBindings(declared, actual, bindings, treatAsDyn)) return null
     if (treatAsDyn) return actual
-
-    const materializedType = this.getType(declared.templated(bindings))
-    return actual.matches(materializedType) ? actual : null
+    return actual.matches(this.getType(declared.templated(bindings))) ? actual : null
   }
 
   #bindPlaceholder(name, candidateType, bindings) {
     const existing = bindings.get(name)
-    if (existing) return existing.matchesBoth(candidateType)
-    bindings.set(name, candidateType)
-    return true
+    if (!existing) return bindings.set(name, candidateType) && true
+    return existing.kind === 'dyn' || candidateType.kind === 'dyn'
+      ? true
+      : existing.matchesBoth(candidateType)
   }
 
   #collectPlaceholderBindings(declared, actual, bindings, fromDyn = false) {
     if (!declared.hasPlaceholder()) return true
+    if (!actual) return false
 
     const treatAsDyn = fromDyn || actual.kind === 'dyn'
     actual = actual.unwrappedType
 
-    if (declared.kind === 'param') {
-      const candidateType = treatAsDyn ? celTypes.dyn : actual
-      return this.#bindPlaceholder(declared.name, candidateType, bindings)
+    switch (declared.kind) {
+      case 'param': {
+        const candidateType = treatAsDyn ? celTypes.dyn : actual
+        return this.#bindPlaceholder(declared.name, candidateType, bindings)
+      }
+      case 'list': {
+        if (actual.name === 'dyn') actual = declared
+        if (actual.kind !== 'list') return false
+        return this.#collectPlaceholderBindings(
+          declared.valueType,
+          actual.valueType,
+          bindings,
+          treatAsDyn
+        )
+      }
+      case 'map': {
+        if (actual.name === 'dyn') actual = declared
+        if (actual.kind !== 'map') return false
+        return (
+          this.#collectPlaceholderBindings(
+            declared.keyType,
+            actual.keyType,
+            bindings,
+            treatAsDyn
+          ) &&
+          this.#collectPlaceholderBindings(
+            declared.valueType,
+            actual.valueType,
+            bindings,
+            treatAsDyn
+          )
+        )
+      }
+      case 'optional': {
+        if (actual.name === 'dyn') actual = declared
+        if (actual.kind !== 'optional') return false
+        return this.#collectPlaceholderBindings(
+          declared.valueType,
+          actual.valueType,
+          bindings,
+          treatAsDyn
+        )
+      }
     }
-
-    if (declared.kind === 'list') {
-      if (actual.name === 'dyn') actual = declared
-      if (actual.kind !== 'list') return false
-      return this.#collectPlaceholderBindings(
-        declared.valueType,
-        actual.valueType,
-        bindings,
-        treatAsDyn
-      )
-    }
-
-    if (declared.kind === 'map') {
-      if (actual.name === 'dyn') actual = declared
-      if (actual.kind !== 'map') return false
-      return (
-        this.#collectPlaceholderBindings(declared.keyType, actual.keyType, bindings, treatAsDyn) &&
-        this.#collectPlaceholderBindings(declared.valueType, actual.valueType, bindings, treatAsDyn)
-      )
-    }
-
     return true
   }
 
@@ -883,27 +994,29 @@ export class Registry {
       operatorDeclarations: this.#operatorDeclarations,
       functionDeclarations: this.#functionDeclarations,
       variables: this.variables,
-      unlistedVariablesAreDyn: opts.unlistedVariablesAreDyn
+      constants: this.constants,
+      unlistedVariablesAreDyn: opts.unlistedVariablesAreDyn,
+      enableOptionalTypes: opts.enableOptionalTypes
     })
   }
 
   /** @param {string} signature */
   #parseFunctionDeclaration(signature, handler) {
-    // Parse "string.indexOf(string, string, integer): integer"
-    const match = signature.match(/^(?:([a-zA-Z0-9.]+)\.)?(\w+)\((.*?)\):\s*(.+)$/)
+    // Parse "optional<A>.value(): A" or "dyn(A): dyn<A>" or "string.indexOf(string): int"
+    const match = signature.match(/^(?:([a-zA-Z0-9.<>]+)\.)?(\w+)\((.*?)\):\s*(.+)$/)
     if (!match) throw new Error(`Invalid signature: ${signature}`)
     const [, receiverType, name, argsStr, _returnType] = match
 
     try {
       return new FunctionDeclaration({
         name: name,
-        receiverType: receiverType ? this.getType(receiverType.trim()) : null,
+        receiverType: receiverType ? this.getType(receiverType) : null,
         returnType: this.getType(_returnType.trim()),
         argTypes: splitByComma(argsStr).map((s) => this.getFunctionType(s.trim())),
         handler
       })
     } catch (e) {
-      throw new Error(`Invalid function declaration: ${signature}`)
+      throw new Error(`Invalid function declaration: ${signature}: ${e.message}`)
     }
   }
 

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,5 +1,6 @@
 import {ASTNode} from './parser.js'
 import {UnsignedInt} from './functions.js'
+import {Optional} from './optional.js'
 
 /**
  * Serialize a primitive value to CEL syntax
@@ -13,6 +14,10 @@ function serializeValue(value) {
   if (typeof value === 'string') return serializeString(value)
   if (value instanceof Uint8Array) return serializeBytes(value)
   if (value instanceof UnsignedInt) return `${value.value}u`
+  if (value instanceof Optional) {
+    if (value.hasValue()) return `optional.of(${serializeValue(value.value())})`
+    return 'optional.none()'
+  }
 
   if (typeof value === 'number') {
     return value % 1 === 0
@@ -75,8 +80,12 @@ export function serialize(ast) {
 
     case '.':
       return `${wrap(args[0], op)}.${args[1]}`
+    case '.?':
+      return `${wrap(args[0], op)}.?${args[1]}`
     case '[]':
       return `${wrap(args[0], op)}[${serialize(args[1])}]`
+    case '[?]':
+      return `${wrap(args[0], op)}[?${serialize(args[1])}]`
 
     case 'call':
       return `${args[0]}(${args[1].map(serialize).join(', ')})`
@@ -169,7 +178,9 @@ const PRECEDENCE = {
   '%': 7,
   '!_': 8,
   '.': 9,
+  '.?': 9,
   '[]': 9,
+  '[?]': 9,
   call: 9,
   rcall: 9
 }
@@ -204,10 +215,14 @@ function needsParentheses(ast, parentOp) {
   if (parentOp === '*' && childOp === '*' && ast[1] instanceof ASTNode && ast[1][0] === '-_')
     return false
 
-  // Member/index access chaining: a.b.c, a[0][1]
+  // Member/index access chaining: a.b.c, a[0][1], a.?b.c
   if (
-    (childOp === '.' || childOp === '[]') &&
-    (parentOp === '.' || parentOp === '[]' || parentOp === 'rcall')
+    (childOp === '.' || childOp === '[]' || childOp === '.?' || childOp === '[?]') &&
+    (parentOp === '.' ||
+      parentOp === '[]' ||
+      parentOp === '.?' ||
+      parentOp === '[?]' ||
+      parentOp === 'rcall')
   )
     return false
 

--- a/lib/type-checker.js
+++ b/lib/type-checker.js
@@ -45,6 +45,9 @@ export class TypeChecker {
       case '.':
       case '[]':
         return (ast.checkedType ??= this.checkAccess(ast, ctx))
+      case '.?':
+      case '[?]':
+        return (ast.checkedType ??= this.checkOptionalAccess(ast, ctx))
       case 'call':
         if (ast.macro) return (ast.checkedType ??= ast.macro.typeCheck(this, ast.macro, ctx))
         return (ast.checkedType ??= this.checkCall(ast, ctx))
@@ -109,10 +112,23 @@ export class TypeChecker {
 
   checkAccess(ast, ctx) {
     const leftType = this.check(ast[1], ctx)
+    if (leftType.kind !== 'optional') return this.#checkAccessOnType(ast, ctx, leftType)
+    const resultType = this.#checkAccessOnType(ast, ctx, leftType.valueType)
+    return this.registry.getOptionalType(resultType)
+  }
+
+  checkOptionalAccess(ast, ctx) {
+    const leftType = this.check(ast[1], ctx)
+    const actualType = leftType.kind === 'optional' ? leftType.valueType : leftType
+    return this.registry.getOptionalType(this.#checkAccessOnType(ast, ctx, actualType, true))
+  }
+
+  #checkAccessOnType(ast, ctx, leftType, allowMissingField = false) {
     if (leftType.kind === 'dyn') return leftType
 
-    const indexType = ast[0] === '[]' ? this.check(ast[2], ctx) : this.getType('string')
-    const indexTypeName = indexType.type
+    const indexTypeName = (
+      ast[0] === '[]' || ast[0] === '[?]' ? this.check(ast[2], ctx) : this.getType('string')
+    ).type
 
     if (leftType.kind === 'list') {
       if (indexTypeName !== 'int' && indexTypeName !== 'dyn') {
@@ -133,10 +149,12 @@ export class TypeChecker {
       }
 
       if (customType.fields) {
-        const keyName = ast[0] === '.' ? ast[2] : undefined
+        const keyName = ast[0] === '.' || ast[0] === '.?' ? ast[2] : undefined
         if (keyName) {
           const fieldType = customType.fields[keyName]
           if (fieldType) return fieldType
+          // For optional access, missing field returns dyn; for regular access, throw
+          if (allowMissingField) return this.getType('dyn')
           throw new this.Error(`No such key: ${keyName}`, ast)
         }
       }
@@ -161,7 +179,7 @@ export class TypeChecker {
     }
 
     const argTypes = args.map((a) => this.check(a, ctx))
-    const decl = functionCandidates.filterByReceiverType(null).findMatch(argTypes)
+    const decl = functionCandidates.findMatch(argTypes, null, this.registry)
 
     if (!decl) {
       throw new this.Error(
@@ -192,7 +210,7 @@ export class TypeChecker {
 
     if (receiverType.kind === 'dyn') return functionCandidates.returnType || receiverType
     const argTypes = args.map((a) => this.check(a, ctx))
-    const decl = functionCandidates.filterByReceiverType(receiverType).findMatch(argTypes)
+    const decl = functionCandidates.findMatch(argTypes, receiverType, this.registry)
 
     if (!decl) {
       throw new this.Error(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -86,10 +86,26 @@ function assertThrows(fn, matcher) {
   return assertError(err, matcher)
 }
 
-const defaultExpectations = new TestEnvironment({unlistedVariablesAreDyn: true})
-const {evaluate, parse, expectEval, expectEvalDeep, expectEvalThrows, expectParseThrows} =
-  defaultExpectations
-export {assert, evaluate, parse, expectEval, expectEvalDeep, expectEvalThrows, expectParseThrows}
+const defaultExpectations = new TestEnvironment({unlistedVariablesAreDyn: true, enableOptionalTypes: true})
+const {
+  evaluate,
+  parse,
+  expectType,
+  expectEval,
+  expectEvalDeep,
+  expectEvalThrows,
+  expectParseThrows
+} = defaultExpectations
+export {
+  assert,
+  evaluate,
+  parse,
+  expectType,
+  expectEval,
+  expectEvalDeep,
+  expectEvalThrows,
+  expectParseThrows
+}
 
 export function expectParseAst(expression, expectedAst) {
   const result = parse(expression)

--- a/test/optional-type.test.js
+++ b/test/optional-type.test.js
@@ -1,0 +1,532 @@
+import assert from 'node:assert/strict'
+import {describe, test} from 'node:test'
+import {
+  expectType,
+  expectEval,
+  expectEvalDeep,
+  expectEvalThrows,
+  expectParseAst
+} from './helpers.js'
+import {Environment, serialize, parse, evaluate} from '../lib/index.js'
+
+describe('optional type:', () => {
+  describe('config flag:', () => {
+    test('parse rejects optional chaining when disabled', () => {
+      assert.throws(() => parse('user.?name'), /Expected IDENTIFIER, got QUESTION/)
+      assert.throws(() => parse('user[?0]'), /Unexpected token: QUESTION/)
+      assert.throws(() => evaluate('optional.of(1)'), /Unknown variable: optional/)
+    })
+
+    test('Environment with enableOptionalTypes parses optional chaining', () => {
+      const env = new Environment({enableOptionalTypes: true, unlistedVariablesAreDyn: true})
+      const fn = env.parse('user.?name.orValue("-")')
+      assert.strictEqual(typeof fn, 'function')
+    })
+  })
+
+  describe('optional class:', () => {
+    test('optional.of() should create an optional with value', () => {
+      expectEval('optional.of(42).hasValue()', true)
+      expectEval('optional.of(42).value()', 42n)
+      expectEval('optional.of(42).orValue(0)', 42n)
+    })
+
+    test('optional.none() should create an empty optional', () => {
+      expectEval('optional.none().hasValue()', false)
+      expectEval('optional.none().orValue(99)', 99n)
+    })
+
+    test('optional.value() should throw on none', () => {
+      expectEvalThrows('optional.none().value()', /optional value is not present/i)
+    })
+
+    test('optional with string value', () => {
+      expectEval('optional.of("hello").hasValue()', true)
+      expectEval('optional.of("hello").value()', 'hello')
+      expectEval('optional.of("hello").orValue("default")', 'hello')
+    })
+
+    test('optional with null value', () => {
+      expectEval('optional.of(null).hasValue()', true)
+      expectEval('optional.of(null).value()', null)
+      expectEval('optional.of(dyn(null)).orValue("default")', null)
+    })
+
+    test('optional with list value', () => {
+      expectEval('optional.of([1, 2, 3]).hasValue()', true)
+      expectEvalDeep('optional.of([1, 2, 3]).value()', [1n, 2n, 3n])
+    })
+  })
+
+  describe('optional.or() method', () => {
+    test('or() returns original optional when it has a value', () => {
+      expectEval('optional.of(42).or(99).hasValue()', true)
+      expectEval('optional.of(42).or(99).value()', 42n)
+    })
+
+    test('or() returns new optional with default when original is empty', () => {
+      expectEval('optional.none().or(99).hasValue()', true)
+      expectEval('optional.none().or(99).value()', 99n)
+    })
+
+    test('or() via CEL expression - with value', () => {
+      expectEval('optional.of(42).or(99).value()', 42n)
+    })
+
+    test('or() via CEL expression - without value', () => {
+      expectEval('optional.none().or(99).value()', 99n)
+    })
+
+    test('or() with different types - string', () => {
+      expectEval('optional.of("hello").or("world").value()', 'hello')
+      expectEval('optional.none().or("world").value()', 'world')
+    })
+
+    test('or() with list values', () => {
+      expectEvalDeep('optional.of([1, 2, 3]).or([4, 5, 6]).value()', [1n, 2n, 3n])
+      expectEvalDeep('optional.none().or([4, 5, 6]).value()', [4n, 5n, 6n])
+    })
+
+    test('or() chaining - first has value via JS', () => {
+      expectEval('optional.of(1).or(2).or(3).value()', 1n)
+    })
+
+    test('or() chaining - takes first default via JS', () => {
+      expectEval('optional.none().or(2).or(3).value()', 2n)
+    })
+
+    test('or() chaining - uses last default if all none via JS', () => {
+      // Note: optional.none().or(x) returns optional<dyn>, so chaining still works
+      expectEval('optional.none().or(null).or(3).value()', null)
+    })
+
+    test('or() with null value is still considered present', () => {
+      expectEval('optional.of(dyn(null)).or(42).value()', null)
+    })
+
+    test('or() return type is optional', () => {
+      expectEval('optional.of(42).or(99).hasValue()', true)
+      expectEval('optional.of(42).or(99).value()', 42n)
+    })
+
+    test('or() combined with orValue()', () => {
+      expectEval('optional.none().or(99).orValue(0)', 99n)
+      expectEval('optional.none().or(null).orValue(0)', null)
+    })
+
+    test('or() accepts dyn fallback', () => {
+      expectEval('optional.of(1).or(dyn("fallback")).value()', 1n)
+      expectEval('optional.none().or(dyn("fallback")).value()', 'fallback')
+    })
+
+    test('or() with .? operator result', () => {
+      const obj1 = {field: 42}
+      const obj2 = {field: 99}
+      expectEval('obj1.?field.or(obj2.field).value()', 42, {obj1, obj2})
+
+      const obj3 = {}
+      expectEval('obj3.?field.or(obj2.field).value()', 99, {obj3, obj2})
+    })
+
+    test('or() preserves type parameter in template matching', () => {
+      // This test verifies that optional<A>.or(A): optional<A> properly binds types
+      expectEval('optional.of(42).or(99).value()', 42n)
+    })
+
+    test('or() with mixed numeric types', () => {
+      // In dynamic context, optional<dyn>.or(int) should work
+      expectEval('optional.none().or(42).value()', 42n)
+    })
+
+    test('or() returns same optional instance when value exists', () => {
+      expectEval('optional.of("test").or("default").value()', 'test')
+    })
+  })
+
+  describe('optional namespace functions', () => {
+    describe('optional.of()', () => {
+      test('should create optional with value', () => {
+        expectEval('optional.of(42).hasValue()', true)
+        expectEval('optional.of(42).value()', 42n)
+      })
+
+      test('should work with string values', () => {
+        expectEval('optional.of("hello").hasValue()', true)
+        expectEval('optional.of("hello").value()', 'hello')
+      })
+
+      test('should work with boolean values', () => {
+        expectEval('optional.of(true).hasValue()', true)
+        expectEval('optional.of(true).value()', true)
+        expectEval('optional.of(false).hasValue()', true)
+        expectEval('optional.of(false).value()', false)
+      })
+
+      test('should work with null', () => {
+        expectEval('optional.of(null).hasValue()', true)
+        expectEval('optional.of(null).value()', null)
+      })
+
+      test('should work with lists', () => {
+        expectEval('optional.of([1, 2, 3]).hasValue()', true)
+        expectEvalDeep('optional.of([1, 2, 3]).value()', [1n, 2n, 3n])
+      })
+
+      test('should work with maps', () => {
+        expectEval('optional.of({"key": "value"}).hasValue()', true)
+        expectEvalDeep('optional.of({"key": "value"}).value()', {key: 'value'})
+      })
+
+      test('should support chaining with other optional methods', () => {
+        expectEval('optional.of(10).orValue(20)', 10n)
+        expectEval('optional.of("test").or("default").value()', 'test')
+      })
+
+      test('should work with variables', () => {
+        expectEval('optional.of(x).value()', 42n, {x: 42n})
+        expectEval('optional.of(name).value()', 'Alice', {name: 'Alice'})
+      })
+
+      test('should work with expressions', () => {
+        expectEval('optional.of(1 + 2).value()', 3n)
+        expectEval('optional.of("hello" + " world").value()', 'hello world')
+      })
+
+      test('should work with dyn expressions on either side', () => {
+        expectEval('optional.of(dyn(1)).orValue("fallback")', 1n)
+        expectEval('optional.of(1).orValue(dyn("fallback"))', 1n)
+      })
+    })
+
+    describe('optional.none()', () => {
+      test('should create empty optional', () => {
+        expectEval('optional.none().hasValue()', false)
+      })
+
+      test('should return default with orValue', () => {
+        expectEval('optional.none().orValue(42)', 42n)
+        expectEval('optional.none().orValue("default")', 'default')
+      })
+
+      test('should return another optional with or', () => {
+        expectEval('optional.none().or(99).value()', 99n)
+        expectEval('optional.none().or("fallback").value()', 'fallback')
+      })
+
+      test('should throw when accessing value()', () => {
+        expectEvalThrows('optional.none().value()')
+      })
+
+      test('should work in conditional expressions', () => {
+        expectEval('optional.none().hasValue() ? "yes" : "no"', 'no')
+      })
+    })
+
+    describe('integration with .? operator', () => {
+      test('should work together with optional chaining', () => {
+        const obj = {field: 42}
+        expectEval('obj.?field.hasValue() && optional.of(10).hasValue()', true, {obj})
+      })
+
+      test('should allow mixing namespace functions with field access optionals', () => {
+        const obj = {value: 5n}
+        expectEval('optional.of(obj.?value.orValue(0)).value()', 5n, {obj})
+      })
+
+      test('should handle none from both sources', () => {
+        const obj = {}
+        expectEval('obj.?missing.hasValue() || optional.none().hasValue()', false, {obj})
+      })
+    })
+
+    describe('type checking', () => {
+      test('optional.of should accept any type', () => {
+        expectType('optional.of(42)', 'optional<int>')
+      })
+
+      test('optional.none should return optional', () => {
+        expectType('optional.none()', 'optional<dyn>')
+      })
+
+      test('should type check chained methods', () => {
+        expectType('optional.of("test").value()', 'string')
+      })
+    })
+  })
+
+  describe('.? operator - evaluation', () => {
+    describe('basic field access', () => {
+      test('should return optional when field exists', () => {
+        const obj = {field: 42}
+        expectEval('obj.?field.hasValue()', true, {obj})
+        expectEval('obj.?field.value()', 42, {obj})
+      })
+
+      test('should return optional.none() when field missing', () => {
+        const obj = {}
+        expectEval('obj.?field.hasValue()', false, {obj})
+      })
+
+      test('chained access with .? should work', () => {
+        const obj = {a: {b: {c: 42}}}
+        expectEval('obj.?a.?b.?c.hasValue()', true, {obj})
+        expectEval('obj.?a.?b.?c.value()', 42, {obj})
+      })
+    })
+
+    describe('viral propagation', () => {
+      test('obj.?missing.field should return optional.none()', () => {
+        const obj = {}
+        expectEval('obj.?missing.field.hasValue()', false, {obj})
+      })
+
+      test('obj.?a.b.c - once .? is used, all subsequent accesses are optional', () => {
+        const obj = {a: {}}
+        expectEval('obj.?a.b.c.hasValue()', false, {obj})
+      })
+
+      test('obj.?a.b.c.d.e - deep nesting should work', () => {
+        const obj = {}
+        expectEval('obj.?missing.deeply.nested.field.hasValue()', false, {obj})
+      })
+
+      test('viral propagation with existing path', () => {
+        const obj = {a: {b: {c: 42}}}
+        expectEval('obj.?a.b.c.hasValue()', true, {obj})
+        expectEval('obj.?a.b.c.value()', 42, {obj})
+      })
+
+      test('viral propagation stops at first missing field', () => {
+        const obj = {a: {b: {}}}
+        expectEval('obj.?a.b.missing.deeply.nested.hasValue()', false, {obj})
+      })
+    })
+
+    describe('orValue() with defaults', () => {
+      test('should use default value when field missing', () => {
+        const obj = {}
+        expectEval('obj.?field.orValue(99)', 99n, {obj})
+      })
+
+      test('should return actual value when present', () => {
+        const obj = {field: 42}
+        expectEval('obj.?field.orValue(99)', 42, {obj})
+      })
+
+      test('chained optional with orValue', () => {
+        const obj = {a: {}}
+        expectEval('obj.?a.b.c.orValue("default")', 'default', {obj})
+      })
+
+      test('orValue with complex default', () => {
+        const obj = {}
+        expectEvalDeep('obj.?field.orValue([1, 2, 3])', [1n, 2n, 3n], {obj})
+      })
+    })
+
+    describe('[? optional index access', () => {
+      test('should return optional for valid index', () => {
+        const items = [1, 2, 3]
+        expectEval('items[?0].hasValue()', true, {items})
+        expectEval('items[?0].value()', 1, {items})
+      })
+
+      test('should return optional.none() for out of bounds', () => {
+        const items = [1, 2, 3]
+        expectEval('items[?10].hasValue()', false, {items})
+      })
+
+      test('should work with map access', () => {
+        const data = {key1: 'value1'}
+        expectEval('data[?"key1"].hasValue()', true, {data})
+        expectEval('data[?"key1"].value()', 'value1', {data})
+      })
+
+      test('map with missing key', () => {
+        const data = {key1: 'value1'}
+        expectEval('data[?"missing"].hasValue()', false, {data})
+      })
+    })
+
+    describe('viral propagation with index access', () => {
+      test('obj.?items[0] should propagate optional', () => {
+        const obj = {items: [1, 2, 3]}
+        expectEval('obj.?items[0].hasValue()', true, {obj})
+        expectEval('obj.?items[0].value()', 1, {obj})
+      })
+
+      test('obj.?missing[0] should return optional.none()', () => {
+        const obj = {}
+        expectEval('obj.?missing[0].hasValue()', false, {obj})
+      })
+
+      test('items[?0].field should propagate optional', () => {
+        const items = [{field: 42}]
+        expectEval('items[?0].field.hasValue()', true, {items})
+        expectEval('items[?0].field.value()', 42, {items})
+      })
+    })
+
+    describe('special values', () => {
+      test('null value is not same as missing', () => {
+        const obj = {field: null}
+        expectEval('obj.?field.hasValue()', true, {obj})
+        expectEval('obj.?field.value()', null, {obj})
+      })
+
+      test('zero is not same as missing', () => {
+        const obj = {count: 0}
+        expectEval('obj.?count.hasValue()', true, {obj})
+        expectEval('obj.?count.value()', 0, {obj})
+      })
+
+      test('false is not same as missing', () => {
+        const obj = {flag: false}
+        expectEval('obj.?flag.hasValue()', true, {obj})
+        expectEval('obj.?flag.value()', false, {obj})
+      })
+
+      test('empty string is not same as missing', () => {
+        const obj = {text: ''}
+        expectEval('obj.?text.hasValue()', true, {obj})
+        expectEval('obj.?text.value()', '', {obj})
+      })
+    })
+
+    describe('mixed optional and regular access', () => {
+      test('regular access before optional', () => {
+        const obj = {a: {b: {c: 42}}}
+        expectEval('obj.a.?b.c.hasValue()', true, {obj})
+        expectEval('obj.a.?b.c.value()', 42, {obj})
+      })
+
+      test('regular access before optional with missing field', () => {
+        const obj = {a: {}}
+        expectEval('obj.a.?missing.field.hasValue()', false, {obj})
+      })
+
+      test('parenthesized optional propagates to subsequent access', () => {
+        // When accessing fields on optional values, it automatically propagates
+        const obj1 = {a: {b: {bar: 42}}}
+        expectEval('(obj.?a.b).bar.orValue(1)', 42, {obj: obj1})
+
+        const obj2 = {a: {}}
+        expectEval('(obj.?a.b).bar.orValue(1)', 1n, {obj: obj2})
+
+        const obj3 = {a: {b: {}}}
+        expectEval('(obj.?a.b).bar.orValue(1)', 1n, {obj: obj3})
+      })
+
+      test('parenthesized optional with .value() unwrapping works', () => {
+        const obj = {a: {b: {bar: 42}}}
+        expectEval('(obj.?a.b).value().bar', 42, {obj})
+      })
+
+      test('viral propagation without parentheses works with orValue', () => {
+        const obj1 = {a: {b: {bar: 42}}}
+        expectEval('obj.?a.b.bar.orValue(1)', 42, {obj: obj1})
+
+        const obj2 = {a: {}}
+        expectEval('obj.?a.b.bar.orValue(1)', 1n, {obj: obj2})
+
+        const obj3 = {a: {b: {}}}
+        expectEval('obj.?a.b.bar.orValue(1)', 1n, {obj: obj3})
+      })
+
+      test('array access on optional propagates', () => {
+        const account = {balance: {items: [1, 2, 3]}}
+        expectEval('(account.balance.?items)[0].orValue(99)', 1, {account})
+
+        const account2 = {balance: {}}
+        expectEval('(account.balance.?items)[0].orValue(99)', 99n, {account: account2})
+      })
+    })
+
+    describe('complex expressions with optional', () => {
+      test('optional in conditional', () => {
+        const obj = {field: 42}
+        expectEval('obj.?field.hasValue() ? obj.?field.value() : 0', 42, {obj})
+      })
+
+      test('optional with missing field in conditional', () => {
+        const obj = {}
+        expectEval('obj.?field.hasValue() ? obj.?field.value() : 0', 0n, {obj})
+      })
+
+      test('optional with arithmetic', () => {
+        const obj = {x: 10n}
+        expectEval('obj.?x.orValue(0) + 5', 15n, {obj})
+      })
+
+      test('optional with missing field and arithmetic', () => {
+        const obj = {}
+        expectEval('obj.?x.orValue(0) + 5', 5n, {obj})
+      })
+
+      test('supports nested optional chaining with .value()', () => {
+        // Can call string methods on .value() result
+        expectEval(`({"foo": {"bar": "hello"}.?bar}).foo.value().size()`, 5n)
+
+        // Without .value(), optional methods must be used
+        expectEvalThrows(
+          `({"foo": {"bar": "hello"}.?bar}).foo.size()`,
+          /found no matching overload for 'optional\.size\(\)'/
+        )
+      })
+
+      test('throws error on invalid access', () => {
+        expectEvalThrows(
+          `({"foo": {"test": [1]}}).?foo.test["2"].orValue(1)`,
+          /List index must be int, got 'string'/
+        )
+      })
+
+      test('complex nested optional with defaults', () => {
+        expectEval(`({"foo": {"test": {"1": "foo"}}}).?foo.test["2"].orValue("3")`, '3')
+      })
+    })
+  })
+
+  describe('.? support for has macro', () => {
+    test('has() works with optional field access', () => {
+      const obj1 = {field: 42}
+      expectEval('has(obj1.field.?foo.foo)', false, {obj1})
+      expectEval('has(obj1.?field.foo.bar)', false, {obj1})
+      expectEval('has(obj1.?field.?foo.bar)', false, {obj1})
+
+      // The last prop can't have .? as it would make has() arg invalid
+      expectEvalThrows(`has(obj1.?field)`, /has\(\) invalid argument/, {obj1})
+      expectEvalThrows(`has(obj1.?field.?foo.?bar)`, /has\(\) invalid argument/, {obj1})
+    })
+  })
+
+  describe('Parser support', () => {
+    const serializationEnv = new Environment({
+      enableOptionalTypes: true,
+      unlistedVariablesAreDyn: true
+    })
+    test('should parse .? operator', () => {
+      expectParseAst('obj.?field', ['.?', ['id', 'obj'], 'field'])
+    })
+
+    test('should parse [? operator', () => {
+      expectParseAst('list[?0]', ['[?]', ['id', 'list'], ['value', 0n]])
+    })
+
+    test('should parse chained optional access', () => {
+      expectParseAst('a.?b.c', ['.', ['.?', ['id', 'a'], 'b'], 'c'])
+    })
+
+    test('should serialize .? operator', () => {
+      const parsed = serializationEnv.parse('obj.?field')
+      const result = serialize(parsed.ast)
+      expectEval('result', 'obj.?field', {result})
+    })
+
+    test('should serialize [? operator', () => {
+      const parsed = serializationEnv.parse('list[?0]')
+      const result = serialize(parsed.ast)
+      expectEval('result', 'list[?0]', {result})
+    })
+  })
+})


### PR DESCRIPTION
### Changelog 
- 🎁 Add first-class support for the optional chaining syntax `.?key` / `.[?key]` together with optional types.
  Please use `enableOptionalTypes: true` to enable the functionality. It is disabled by default.