### PR TITLE
Fix support for metro

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -120,16 +120,24 @@ export class TypeDeclaration {
     else if (kind === 'message') this.fieldLazy = this.#getMessageField
     else if (kind === 'optional') this.fieldLazy = this.#getOptionalField
 
+    this.#hasDynTypes =
+      this.kind === 'dyn' || this.valueType?.hasDyn() || this.keyType?.hasDyn() || false
+
+    this.#hasPlaceholderTypes =
+      this.kind === 'param' ||
+      this.keyType?.hasPlaceholder() ||
+      this.valueType?.hasPlaceholder() ||
+      false
+
     objFreeze(this)
   }
 
   hasDyn() {
-    return (this.#hasDynTypes ??=
-      this.kind === 'dyn' || this.valueType?.hasDyn() || this.keyType?.hasDyn() || false)
+    return this.#hasDynTypes
   }
 
   hasNoDynTypes() {
-    return this.hasDyn() === false
+    return this.#hasDynTypes === false
   }
 
   isDynOrBool() {
@@ -141,11 +149,7 @@ export class TypeDeclaration {
   }
 
   hasPlaceholder() {
-    return (this.#hasPlaceholderTypes ??=
-      this.kind === 'param' ||
-      this.keyType?.hasPlaceholder() ||
-      this.valueType?.hasPlaceholder() ||
-      false)
+    return this.#hasPlaceholderTypes
   }
 
   unify(r, t2) {
@@ -321,15 +325,18 @@ export class FunctionDeclaration {
     const receiverString = receiverType ? `${receiverType}.` : ''
     this.signature = `${receiverString}${name}(${argTypes.join(', ')}): ${returnType}`
     this.handler = this.macro ? wrapMacroExpander(this.signature, handler) : handler
+
+    this.#hasPlaceholderTypes =
+      this.returnType.hasPlaceholder() ||
+      this.receiverType?.hasPlaceholder() ||
+      this.argTypes.some((t) => t.hasPlaceholder()) ||
+      false
+
     objFreeze(this)
   }
 
   hasPlaceholder() {
-    return (this.#hasPlaceholderTypes ??=
-      this.returnType.hasPlaceholder() ||
-      this.receiverType?.hasPlaceholder() ||
-      this.argTypes.some((t) => t.hasPlaceholder()) ||
-      false)
+    return this.#hasPlaceholderTypes
   }
 
   matchesArgs(argTypes) {
@@ -352,12 +359,14 @@ export class OperatorDeclaration {
     if (rightType) this.signature = `${leftType} ${operator} ${rightType}: ${returnType}`
     else this.signature = `${operator}${leftType}: ${returnType}`
 
+    this.#hasPlaceholderTypes =
+      this.leftType.hasPlaceholder() || this.rightType?.hasPlaceholder() || false
+
     objFreeze(this)
   }
 
   hasPlaceholder() {
-    return (this.#hasPlaceholderTypes ??=
-      this.leftType.hasPlaceholder() || this.rightType?.hasPlaceholder() || false)
+    return this.#hasPlaceholderTypes
   }
 
   equals(other) {


### PR DESCRIPTION
Fixes #80 

### Changelog
- 🐛 Move lazy evaluated private fields into constructor as [metro](https://github.com/facebook/metro) compiles private fields to regular properties and therefore doesn't conform to the spec