### PR TITLE
types: overloads, exports, definitions introspection

### DIFF
--- a/lib/evaluator.d.ts
+++ b/lib/evaluator.d.ts
@@ -1,4 +1,16 @@
-export * from './index.js'
+import {Environment, check, evaluate, parse} from './index.js'
+import {Duration, UnsignedInt} from './functions.js'
 
-// Re-export Duration and UnsignedInt from functions.js
+export {Environment, check, evaluate, parse}
 export {Duration, UnsignedInt} from './functions.js'
+
+declare const evaluator: {
+  parse: typeof parse
+  evaluate: typeof evaluate
+  check: typeof check
+  Environment: typeof Environment
+  Duration: typeof Duration
+  UnsignedInt: typeof UnsignedInt
+}
+
+export default evaluator

--- a/lib/functions.d.ts
+++ b/lib/functions.d.ts
@@ -20,6 +20,9 @@ export class UnsignedInt {
 
   /** Convert to string representation. */
   toString(): string
+
+  /** Validate and store an unsigned integer value. */
+  verify(v: bigint): void
 }
 
 /**
@@ -40,11 +43,38 @@ export class Duration {
   /** Get the nanoseconds component. */
   get nanos(): number
 
-  /** Convert to primitive bigint (seconds only) for operations. */
-  valueOf(): bigint
+  /** Construct a duration from a millisecond value. */
+  static fromMilliseconds(ms: number): Duration
+
+  /** Convert to primitive milliseconds for operations. */
+  valueOf(): number
+
+  /** Add another duration. */
+  addDuration(other: Duration): Duration
+
+  /** Subtract another duration. */
+  subtractDuration(other: Duration): Duration
+
+  /** Add this duration to a timestamp. */
+  extendTimestamp(timestamp: Date): Date
+
+  /** Subtract this duration from a timestamp. */
+  subtractTimestamp(timestamp: Date): Date
 
   /** Convert to string representation in format like "5s", "1h30m", etc. */
   toString(): string
+
+  /** Whole hours represented by this duration. */
+  getHours(): bigint
+
+  /** Whole minutes represented by this duration. */
+  getMinutes(): bigint
+
+  /** Whole seconds represented by this duration. */
+  getSeconds(): bigint
+
+  /** Total milliseconds represented by this duration. */
+  getMilliseconds(): bigint
 }
 
 /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
 import type {UnsignedInt} from './functions.js'
+import type {ObjectSchema, TypeDeclaration} from './registry.d'
 
 /**
  * Represents a CEL expression AST node produced by the parser.
@@ -266,6 +267,26 @@ export interface EnvironmentOptions {
   limits?: Partial<Limits>
 }
 
+export type RegisteredVariableType = string | TypeDeclaration
+
+export interface RegisterVariableMetadata {
+  description?: string
+}
+
+export interface RegisterVariableTypeOptions extends RegisterVariableMetadata {
+  type: RegisteredVariableType
+}
+
+export interface RegisterVariableSchemaOptions extends RegisterVariableMetadata {
+  schema: ObjectSchema
+}
+
+export type RegisterVariableOptions = RegisterVariableTypeOptions | RegisterVariableSchemaOptions
+
+export type RegisterVariableDeclaration = {name: string} & RegisterVariableOptions
+
+export type RegisterConstantDeclaration = {name: string; value: any} & RegisterVariableOptions
+
 export type RegisteredFunctionHandler = (...args: any[]) => any
 
 export interface RegisteredFunctionParam {
@@ -348,34 +369,40 @@ export class Environment {
   /**
    * Register a variable with its expected type.
    *
-   * @param name - The variable name
-   * @param type - The CEL type name ('string', 'int', 'double', 'bool', 'list', 'map', etc.)
+   * Supports `name + type`, `name + {type|schema}`, and a single declaration object.
    * @returns This environment for chaining
    * @throws Error if variable is already registered
    *
    * @example
    * ```typescript
    * env.registerVariable('username', 'string')
-   *    .registerVariable('count', 'int')
+   * env.registerVariable('user', {type: 'map', description: 'The current user'})
+   * env.registerVariable({name: 'profile', schema: {email: 'string'}})
    * ```
    */
-  registerVariable(name: string, type: string): this
+  registerVariable(
+    name: string,
+    type: RegisteredVariableType,
+    opts?: RegisterVariableMetadata
+  ): this
+  registerVariable(name: string, options: RegisterVariableOptions): this
+  registerVariable(definition: RegisterVariableDeclaration): this
 
   /**
    * Register a constant value that is always available in expressions without providing it via context.
    *
-   * @param name - The constant identifier exposed to CEL expressions
-   * @param type - The CEL type name of the constant (e.g., 'int', 'string')
-   * @param value - The concrete value supplied during registration
+   * Supports `name + type + value` and a single declaration object.
    * @returns This environment for chaining further registrations
    *
    * @example
    * ```typescript
    * const env = new Environment().registerConstant('timezone', 'string', 'UTC')
+   * env.registerConstant({name: 'minAge', type: 'int', value: 18n, description: 'Minimum age'})
    * env.evaluate('timezone == "UTC"') // true
    * ```
    */
-  registerConstant(name: string, type: string, value: any): this
+  registerConstant(name: string, type: RegisteredVariableType, value: any): this
+  registerConstant(definition: RegisterConstantDeclaration): this
 
   /**
    * Register a custom function or method.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -266,6 +266,41 @@ export interface EnvironmentOptions {
   limits?: Partial<Limits>
 }
 
+export type RegisteredFunctionHandler = (...args: any[]) => any
+
+export interface RegisteredFunctionParam {
+  name?: string
+  type?: string
+  description?: string
+}
+
+export interface RegisteredFunctionTypedParam extends RegisteredFunctionParam {
+  type: string
+}
+
+export interface RegisterFunctionMetadata {
+  description?: string
+  params?: RegisteredFunctionParam[]
+  async?: boolean
+}
+
+export interface RegisterFunctionOptions extends RegisterFunctionMetadata {
+  handler: RegisteredFunctionHandler
+}
+
+export interface RegisterFunctionWithSignature extends RegisterFunctionOptions {
+  signature: string
+}
+
+export interface RegisterFunctionWithName extends Omit<RegisterFunctionOptions, 'params'> {
+  name: string
+  receiverType?: string
+  returnType: string
+  params: RegisteredFunctionTypedParam[]
+}
+
+export type RegisterFunctionDeclaration = RegisterFunctionWithSignature | RegisterFunctionWithName
+
 /**
  * Environment for CEL expression evaluation with type checking and custom functions.
  *
@@ -345,8 +380,7 @@ export class Environment {
   /**
    * Register a custom function or method.
    *
-   * @param signature - Function signature in format 'name(type1, type2): returnType' or 'Type.method(args): returnType'
-   * @param handlerOrOptions - Either the function implementation or an options object with handler and optional typeCheck
+   * Supports signature-based registration as well as a single declaration object.
    * @returns This environment for chaining
    *
    * @example
@@ -354,25 +388,28 @@ export class Environment {
    * // Standalone function
    * env.registerFunction('double(int): int', (x) => x * 2n)
    *
-   * // Instance method
-   * env.registerFunction('string.reverse(): string', (str) => str.split('').reverse().join(''))
+   * // Signature string with descriptions
+   * env.registerFunction('greet(string): string', handler, {description: 'Greets someone'})
    *
-   * // Macro function with type checker
-   * env.registerFunction('list.custom(ast, ast): bool', {
-   *   handler: (receiver, ast) => { ... },
-   *   typeCheck: (checker, receiverType, args) => 'bool'
+   * // Single object with signature and named params
+   * env.registerFunction({
+   *   signature: 'formatDate(int, string): string',
+   *   handler,
+   *   description: 'Formats a timestamp',
+   *   params: [
+   *     {name: 'timestamp', description: 'Unix timestamp in seconds'},
+   *     {name: 'format', description: 'Date format string'}
+   *   ]
    * })
    * ```
    */
   registerFunction(
     signature: string,
-    handlerOrOptions:
-      | ((...args: any[]) => any)
-      | {
-          handler: (...args: any[]) => any
-          typeCheck?: (checker: any, receiverType: string, args: any[]) => string
-        }
+    handler: RegisteredFunctionHandler,
+    opts?: RegisterFunctionMetadata
   ): this
+  registerFunction(signature: string, options: RegisterFunctionOptions): this
+  registerFunction(definition: RegisterFunctionDeclaration): this
 
   /**
    * Register a custom operator overload.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,18 @@
 import type {UnsignedInt} from './functions.js'
-import type {ObjectSchema, TypeDeclaration} from './registry.d'
+import type {
+  DefinitionsResult,
+  RegisterConstantDeclaration,
+  RegisterFunctionDeclaration,
+  RegisterFunctionHandler,
+  RegisterFunctionMetadata,
+  RegisterFunctionOptions,
+  RegisterTypeDeclaration,
+  RegisterTypeDefinition,
+  RegisterVariableDeclaration,
+  RegisterVariableMetadata,
+  RegisterVariableOptions,
+  RegisteredVariableType
+} from './registry.js'
 
 /**
  * Represents a CEL expression AST node produced by the parser.
@@ -82,11 +95,37 @@ export type ASTNode = {
  * Context object for variable resolution during evaluation.
  * Can contain any nested structure of primitive values, arrays, and objects.
  */
-export interface Context {
-  [key: string]: any
-}
+export type Context = Record<string, any>
 
-export type {RootContext, OverlayContext} from './registry.d'
+export type {
+  DefinitionFunction,
+  DefinitionFunctionParam,
+  DefinitionsResult,
+  DefinitionVariable,
+  ObjectSchema,
+  OverlayContext,
+  RegisterConstantDeclaration,
+  RegisterFunctionDeclaration,
+  RegisterFunctionHandler,
+  RegisterFunctionMetadata,
+  RegisterFunctionOptions,
+  RegisterFunctionWithName,
+  RegisterFunctionWithSignature,
+  RegisterTypeDeclaration,
+  RegisterTypeDefinition,
+  RegisteredFunctionParam,
+  RegisteredFunctionTypedParam,
+  RegisteredType,
+  RegisteredTypeFieldDeclaration,
+  RegisteredVariableType,
+  RegisterVariableDeclaration,
+  RegisterVariableMetadata,
+  RegisterVariableOptions,
+  RegisterVariableSchemaOptions,
+  RegisterVariableTypeOptions,
+  RootContext,
+  TypeDeclaration
+} from './registry.js'
 
 /**
  * Result of type checking an expression.
@@ -96,8 +135,8 @@ export interface TypeCheckResult {
   valid: boolean
   /** The inferred type of the expression (only present if valid is true) */
   type?: string
-  /** The type error that occurred (only present if valid is false) */
-  error?: TypeError
+  /** The parse or type error that occurred (only present if valid is false) */
+  error?: ParseError | TypeError
 }
 
 export type ParseResult = {
@@ -112,16 +151,20 @@ export type ParseResult = {
  * Error thrown during parsing when the CEL expression syntax is invalid.
  */
 export class ParseError extends Error {
-  constructor(message: string)
+  constructor(message: string, node?: ASTNode, cause?: unknown)
   readonly name: 'ParseError'
+  readonly node?: ASTNode
+  withAst(node: ASTNode): this
 }
 
 /**
  * Error thrown during evaluation when an error occurs while executing the CEL expression.
  */
 export class EvaluationError extends Error {
-  constructor(message: string)
+  constructor(message: string, node?: ASTNode, cause?: unknown)
   readonly name: 'EvaluationError'
+  readonly node?: ASTNode
+  withAst(node: ASTNode): this
 }
 
 /**
@@ -129,27 +172,29 @@ export class EvaluationError extends Error {
  * The error message includes source position highlighting.
  */
 export class TypeError extends Error {
-  constructor(message: string)
+  constructor(message: string, node?: ASTNode, cause?: unknown)
   readonly name: 'TypeError'
+  readonly node?: ASTNode
+  withAst(node: ASTNode): this
 }
 
 /**
  * Represents an optional value that may or may not be present.
  * Used with optional chaining (.?/.[]?) and optional.* helpers.
  */
-export class Optional {
+export class Optional<T = unknown> {
   /**
    * Create a new Optional with a value.
    * @param value - The value to wrap
    * @returns A new Optional instance
    */
-  static of(value: any): Optional
+  static of<T>(value: T): Optional<T>
 
   /**
    * Create an empty Optional.
    * @returns The singleton empty Optional instance
    */
-  static none(): Optional
+  static none(): Optional<never>
 
   /** Check if a value is present. */
   hasValue(): boolean
@@ -159,21 +204,21 @@ export class Optional {
    * @returns The wrapped value
    * @throws EvaluationError if no value is present
    */
-  value(): any
+  value(): T
 
   /**
    * Return this Optional if it has a value, otherwise return the provided Optional.
    * @param optional - The fallback Optional
    * @returns An Optional instance
    */
-  or(optional: Optional): Optional
+  or<U>(optional: Optional<U>): Optional<T | U>
 
   /**
    * Return the wrapped value if present, otherwise return the default value.
    * @param defaultValue - The fallback value
    * @returns The resulting value
    */
-  orValue(defaultValue: any): any
+  orValue<U>(defaultValue: U): T | U
 }
 
 /**
@@ -212,6 +257,14 @@ export function parse(expression: string): ParseResult
  * ```
  */
 export function evaluate(expression: string, context?: Context): any
+
+/**
+ * Type check a CEL expression string directly.
+ *
+ * @param expression - The CEL expression string to check
+ * @returns Validation result with inferred type or error details
+ */
+export function check(expression: string): TypeCheckResult
 
 /**
  * Serialize an AST back to a CEL expression string.
@@ -267,60 +320,9 @@ export interface EnvironmentOptions {
   limits?: Partial<Limits>
 }
 
-export type RegisteredVariableType = string | TypeDeclaration
-
-export interface RegisterVariableMetadata {
-  description?: string
+export type ResolvedEnvironmentOptions = Omit<Required<EnvironmentOptions>, 'limits'> & {
+  limits: Limits
 }
-
-export interface RegisterVariableTypeOptions extends RegisterVariableMetadata {
-  type: RegisteredVariableType
-}
-
-export interface RegisterVariableSchemaOptions extends RegisterVariableMetadata {
-  schema: ObjectSchema
-}
-
-export type RegisterVariableOptions = RegisterVariableTypeOptions | RegisterVariableSchemaOptions
-
-export type RegisterVariableDeclaration = {name: string} & RegisterVariableOptions
-
-export type RegisterConstantDeclaration = {name: string; value: any} & RegisterVariableOptions
-
-export type RegisteredFunctionHandler = (...args: any[]) => any
-
-export interface RegisteredFunctionParam {
-  name?: string
-  type?: string
-  description?: string
-}
-
-export interface RegisteredFunctionTypedParam extends RegisteredFunctionParam {
-  type: string
-}
-
-export interface RegisterFunctionMetadata {
-  description?: string
-  params?: RegisteredFunctionParam[]
-  async?: boolean
-}
-
-export interface RegisterFunctionOptions extends RegisterFunctionMetadata {
-  handler: RegisteredFunctionHandler
-}
-
-export interface RegisterFunctionWithSignature extends RegisterFunctionOptions {
-  signature: string
-}
-
-export interface RegisterFunctionWithName extends Omit<RegisterFunctionOptions, 'params'> {
-  name: string
-  receiverType?: string
-  returnType: string
-  params: RegisteredFunctionTypedParam[]
-}
-
-export type RegisterFunctionDeclaration = RegisterFunctionWithSignature | RegisterFunctionWithName
 
 /**
  * Environment for CEL expression evaluation with type checking and custom functions.
@@ -336,6 +338,9 @@ export type RegisterFunctionDeclaration = RegisterFunctionWithSignature | Regist
  * ```
  */
 export class Environment {
+  /** The fully resolved options for this environment instance. */
+  readonly opts: ResolvedEnvironmentOptions
+
   /**
    * Create a new Environment with optional configuration.
    *
@@ -355,16 +360,19 @@ export class Environment {
    * Register a custom type for use in expressions.
    *
    * @param typename - The name of the type (e.g., 'Vector', 'Point')
-   * @param constructor - The constructor function or class for the type
+   * @param definition - The type constructor or registration object
    * @returns This environment for chaining
    *
    * @example
    * ```typescript
    * class Vector { constructor(public x: number, public y: number) {} }
    * env.registerType('Vector', Vector)
+   * env.registerType('Vector', {ctor: Vector, fields: {x: 'double', y: 'double'}})
+   * env.registerType({name: 'Vector', schema: {x: 'double', y: 'double'}})
    * ```
    */
-  registerType(typename: string, constructor: any): this
+  registerType(typename: string, definition: RegisterTypeDefinition): this
+  registerType(definition: RegisterTypeDeclaration): this
 
   /**
    * Register a variable with its expected type.
@@ -408,6 +416,9 @@ export class Environment {
    * Register a custom function or method.
    *
    * Supports signature-based registration as well as a single declaration object.
+   * @param signature - Function signature in format 'name(type1, type2): returnType' or 'Type.method(args): returnType'
+   * @param handler - The function implementation
+   * @param opts - Optional metadata such as descriptions, param docs, and async hints
    * @returns This environment for chaining
    *
    * @example
@@ -417,6 +428,9 @@ export class Environment {
    *
    * // Signature string with descriptions
    * env.registerFunction('greet(string): string', handler, {description: 'Greets someone'})
+   *
+   * // Instance method
+   * env.registerFunction('string.reverse(): string', (str) => str.split('').reverse().join(''))
    *
    * // Single object with signature and named params
    * env.registerFunction({
@@ -428,6 +442,17 @@ export class Environment {
    *     {name: 'format', description: 'Date format string'}
    *   ]
    * })
+   *
+   * // Macro function
+   * env.registerFunction('macro(ast): dyn', ({args}) => ({
+   *   firstArgument: args[0],
+   *   typeCheck(checker, macro, ctx) {
+   *     return checker.check(macro.firstArgument, ctx)
+   *   },
+   *   evaluate(evaluator, macro, ctx) {
+   *     return evaluator.eval(macro.firstArgument, ctx)
+   *   }
+   * }))
    * ```
    */
   registerFunction(
@@ -451,6 +476,12 @@ export class Environment {
    * ```
    */
   registerOperator(signature: string, handler: (left: any, right: any) => any): this
+
+  /**
+   * Return user-facing definitions for all registered variables and functions,
+   * including the built-ins inherited from the global environment.
+   */
+  getDefinitions(): DefinitionsResult
 
   /**
    * Check if a variable is registered in this environment.
@@ -522,6 +553,7 @@ export class Environment {
 declare const cel: {
   parse: typeof parse
   evaluate: typeof evaluate
+  check: typeof check
   serialize: typeof serialize
   Environment: typeof Environment
   ParseError: typeof ParseError

--- a/lib/registry.d.ts
+++ b/lib/registry.d.ts
@@ -213,7 +213,11 @@ export type RegisterTypeDeclaration =
   | (NamedTypeIdentity & RegisterTypeWithFields)
   | (NamedTypeIdentity & RegisterTypeWithSchema)
 
-export type RegisterTypeDefinition = Function | RegisterTypeDeclaration
+export type RegisterTypeDefinition =
+  | Function
+  | RegisterTypeWithCtor
+  | RegisterTypeWithFields
+  | RegisterTypeWithSchema
 
 export interface RegisteredType {
   name: string

--- a/lib/registry.d.ts
+++ b/lib/registry.d.ts
@@ -24,7 +24,7 @@ export class TypeDeclaration {
    * @param options - Type declaration options
    */
   constructor(options: {
-    kind: 'primitive' | 'list' | 'map' | 'message' | 'enum'
+    kind: 'primitive' | 'list' | 'map' | 'message' | 'enum' | 'dyn' | 'optional' | 'param'
     type: string
     name: string
     keyType?: TypeDeclaration
@@ -32,8 +32,8 @@ export class TypeDeclaration {
     values?: Record<string, bigint>
   })
 
-  /** The kind of type (primitive, list, map, message, enum). */
-  kind: 'primitive' | 'list' | 'map' | 'message' | 'enum'
+  /** The kind of type (primitive, list, map, message, enum, dyn, optional, param). */
+  kind: 'primitive' | 'list' | 'map' | 'message' | 'enum' | 'dyn' | 'optional' | 'param'
 
   /** The type name. */
   type: string
@@ -50,8 +50,29 @@ export class TypeDeclaration {
   /** For enum types, the enum values. */
   values?: Record<string, bigint>
 
+  /** The underlying non-dyn type. */
+  unwrappedType: TypeDeclaration
+
+  /** A wrapped dyn variant of this type. */
+  wrappedType: TypeDeclaration
+
+  /** True when this declaration contains dyn anywhere in its structure. */
+  hasDynType: boolean
+
+  /** True when this declaration contains placeholder type parameters. */
+  hasPlaceholderType: boolean
+
   /** Check if this type is 'dyn' or 'bool'. */
   isDynOrBool(): boolean
+
+  /** Check if this declaration represents an empty aggregate placeholder. */
+  isEmpty(): boolean
+
+  /** Attempt to unify this declaration with another declaration. */
+  unify(registry: Registry, other: TypeDeclaration): TypeDeclaration | null
+
+  /** Replace placeholder types using the provided bindings. */
+  templated(registry: Registry, bind?: Map<string, TypeDeclaration>): TypeDeclaration
 
   /** Convert to string representation. */
   toString(): string
@@ -86,6 +107,7 @@ export const celTypes: {
   dyn: TypeDeclaration
   null: TypeDeclaration
   type: TypeDeclaration
+  optional: TypeDeclaration
   list: TypeDeclaration
   'list<dyn>': TypeDeclaration
   map: TypeDeclaration
@@ -157,6 +179,87 @@ export interface RegisterFunctionWithName extends Omit<RegisterFunctionOptions, 
 
 export type RegisterFunctionDeclaration = RegisterFunctionWithSignature | RegisterFunctionWithName
 
+export type RegisteredTypeFieldDeclaration =
+  | string
+  | {
+      id?: number
+      keyType?: string
+      map?: boolean
+      repeated?: boolean
+      type?: string
+    }
+
+export interface RegisterTypeWithCtor {
+  ctor: Function
+  fields?: Record<string, RegisteredTypeFieldDeclaration>
+  convert?: (value: any) => any
+}
+
+export interface RegisterTypeWithFields {
+  fields: Record<string, RegisteredTypeFieldDeclaration>
+  convert?: (value: any) => any
+}
+
+export interface RegisterTypeWithSchema {
+  schema: ObjectSchema
+  ctor?: Function
+  convert?: (value: any) => any
+}
+
+export type NamedTypeIdentity = {name: string; fullName?: string} | {fullName: string; name?: string}
+
+export type RegisterTypeDeclaration =
+  | ({name?: string; fullName?: string} & RegisterTypeWithCtor)
+  | (NamedTypeIdentity & RegisterTypeWithFields)
+  | (NamedTypeIdentity & RegisterTypeWithSchema)
+
+export type RegisterTypeDefinition = Function | RegisterTypeDeclaration
+
+export interface RegisteredType {
+  name: string
+  typeType: Type
+  type: TypeDeclaration
+  ctor: Function
+  convert?: (value: any) => any
+  fields?: Record<string, TypeDeclaration>
+}
+
+export class VariableDeclaration {
+  constructor(name: string, type: TypeDeclaration, description?: string | null, value?: any)
+
+  readonly name: string
+  readonly type: TypeDeclaration
+  readonly description: string | null
+  readonly constant: boolean
+  readonly value: any
+}
+
+export interface DefinitionVariable {
+  name: string
+  description: string | null
+  type: string
+}
+
+export interface DefinitionFunctionParam {
+  name: string
+  type: string
+  description: string | null
+}
+
+export interface DefinitionFunction {
+  signature: string
+  name: string
+  description: string | null
+  receiverType: string | null
+  returnType: string
+  params: DefinitionFunctionParam[]
+}
+
+export interface DefinitionsResult {
+  variables: DefinitionVariable[]
+  functions: DefinitionFunction[]
+}
+
 /**
  * Registry for managing function overloads, operator overloads, and type mappings.
  */
@@ -169,6 +272,9 @@ export class Registry {
 
   /**
    * Register a function overload.
+   * @param signature - Function signature in format 'name(type1, type2): returnType' or 'Type.method(args): returnType'
+   * @param handler - The function implementation
+   * @param opts - Optional metadata such as descriptions, param docs, and async hints
    * Supports signature-based registration as well as a single declaration object.
    */
   registerFunctionOverload(
@@ -191,15 +297,13 @@ export class Registry {
    * When `ctor` is omitted but `fields` is provided, an internal wrapper class is auto-generated
    * and a default `convert` function is created to wrap plain objects at runtime.
    * @param typename - The name of the type
-   * @param definition - Either a constructor function or an object with ctor/fields/convert
+   * @param definition - A constructor function or registration object with ctor, fields, schema, and/or convert
    */
   registerType(
     typename: string,
-    definition:
-      | Function
-      | {ctor: Function; fields?: Record<string, string>; convert?: (value: any) => any}
-      | {fields: Record<string, string>; convert?: (value: any) => any}
-  ): void
+    definition: RegisterTypeDefinition
+  ): RegisteredType
+  registerType(definition: RegisterTypeDeclaration): RegisteredType
 
   /**
    * Get type declaration for a given type string.
@@ -256,14 +360,17 @@ export class Registry {
    */
   clone(opts?: {unlistedVariablesAreDyn?: boolean; enableOptionalTypes?: boolean}): Registry
 
+  /** Read back user-facing variable/function definitions. */
+  getDefinitions(): DefinitionsResult
+
   /** Registered object types keyed by CEL typename. */
-  readonly objectTypes: Map<string, any>
+  readonly objectTypes: Map<string, RegisteredType>
 
   /** Map of constructors to their registered type metadata. */
-  readonly objectTypesByConstructor: Map<Function | undefined, any>
+  readonly objectTypesByConstructor: Map<Function | undefined, RegisteredType>
 
   /** Registered variables and their type declarations. */
-  readonly variables: Map<string, TypeDeclaration>
+  readonly variables: Map<string, VariableDeclaration>
 
   /** Whether optional types/functions are enabled for this registry. */
   readonly enableOptionalTypes: boolean
@@ -273,12 +380,12 @@ export class Registry {
  * Options for creating a new registry.
  */
 export interface RegistryOptions {
-  objectTypes?: Map<string, any>
-  objectTypesByConstructor?: Map<Function | undefined, any>
+  objectTypes?: Map<string, RegisteredType>
+  objectTypesByConstructor?: Map<Function | undefined, RegisteredType>
   functionDeclarations?: Map<string, any>
   operatorDeclarations?: Map<string, any>
   typeDeclarations?: Map<string, TypeDeclaration>
-  variables?: Map<string, TypeDeclaration>
+  variables?: Map<string, VariableDeclaration>
   unlistedVariablesAreDyn?: boolean
   enableOptionalTypes?: boolean
 }

--- a/lib/registry.d.ts
+++ b/lib/registry.d.ts
@@ -102,6 +102,41 @@ export interface ObjectSchema {
   [field: string]: string | ObjectSchema
 }
 
+export type RegisteredFunctionHandler = (...args: any[]) => any
+
+export interface RegisteredFunctionParam {
+  name?: string
+  type?: string
+  description?: string
+}
+
+export interface RegisteredFunctionTypedParam extends RegisteredFunctionParam {
+  type: string
+}
+
+export interface RegisterFunctionMetadata {
+  description?: string
+  params?: RegisteredFunctionParam[]
+  async?: boolean
+}
+
+export interface RegisterFunctionOptions extends RegisterFunctionMetadata {
+  handler: RegisteredFunctionHandler
+}
+
+export interface RegisterFunctionWithSignature extends RegisterFunctionOptions {
+  signature: string
+}
+
+export interface RegisterFunctionWithName extends Omit<RegisterFunctionOptions, 'params'> {
+  name: string
+  receiverType?: string
+  returnType: string
+  params: RegisteredFunctionTypedParam[]
+}
+
+export type RegisterFunctionDeclaration = RegisterFunctionWithSignature | RegisterFunctionWithName
+
 /**
  * Registry for managing function overloads, operator overloads, and type mappings.
  */
@@ -114,18 +149,15 @@ export class Registry {
 
   /**
    * Register a function overload.
-   * @param signature - Function signature in format 'name(type1, type2): returnType' or 'Type.method(args): returnType'
-   * @param handlerOrOptions - Either the function implementation or an options object with handler and optional typeCheck
+   * Supports signature-based registration as well as a single declaration object.
    */
   registerFunctionOverload(
     signature: string,
-    handlerOrOptions:
-      | ((...args: any[]) => any)
-      | {
-          handler: (...args: any[]) => any
-          typeCheck?: (checker: any, receiverType: string, args: any[]) => string
-        }
+    handler: RegisteredFunctionHandler,
+    opts?: RegisterFunctionMetadata
   ): void
+  registerFunctionOverload(signature: string, options: RegisterFunctionOptions): void
+  registerFunctionOverload(definition: RegisterFunctionDeclaration): void
 
   /**
    * Register an operator overload.

--- a/lib/registry.d.ts
+++ b/lib/registry.d.ts
@@ -102,6 +102,26 @@ export interface ObjectSchema {
   [field: string]: string | ObjectSchema
 }
 
+export type RegisteredVariableType = string | TypeDeclaration
+
+export interface RegisterVariableMetadata {
+  description?: string
+}
+
+export interface RegisterVariableTypeOptions extends RegisterVariableMetadata {
+  type: RegisteredVariableType
+}
+
+export interface RegisterVariableSchemaOptions extends RegisterVariableMetadata {
+  schema: ObjectSchema
+}
+
+export type RegisterVariableOptions = RegisterVariableTypeOptions | RegisterVariableSchemaOptions
+
+export type RegisterVariableDeclaration = {name: string} & RegisterVariableOptions
+
+export type RegisterConstantDeclaration = {name: string; value: any} & RegisterVariableOptions
+
 export type RegisteredFunctionHandler = (...args: any[]) => any
 
 export interface RegisteredFunctionParam {
@@ -192,17 +212,18 @@ export class Registry {
    * Register a variable with its type, throwing if it already exists.
    * When an ObjectSchema is provided via `{schema: ...}`, a type is auto-registered
    * via `registerType` with runtime conversion support.
-   * @param name - The variable name
-   * @param type - The variable type name, declaration, or options with schema
+   * Supports `name + type`, `name + {type|schema}`, and a single declaration object.
    */
-  registerVariable(
-    name: string,
-    type:
-      | string
-      | TypeDeclaration
-      | {type: string; description?: string}
-      | {schema: ObjectSchema; description?: string}
-  ): this
+  registerVariable(name: string, type: RegisteredVariableType, opts?: RegisterVariableMetadata): this
+  registerVariable(name: string, options: RegisterVariableOptions): this
+  registerVariable(definition: RegisterVariableDeclaration): this
+
+  /**
+   * Register a constant value that is always available without requiring evaluation context.
+   * Supports `name + type + value` and a single declaration object.
+   */
+  registerConstant(name: string, type: RegisteredVariableType, value: any): this
+  registerConstant(definition: RegisterConstantDeclaration): this
 
   /**
    * Register a unary operator overload.

--- a/lib/serialize.d.ts
+++ b/lib/serialize.d.ts
@@ -1,1 +1,8 @@
-export {serialize, ASTNode} from './index'
+import type {ASTNode} from './index.js'
+
+export function serialize(ast: ASTNode): string
+
+declare const serializeDefault: typeof serialize
+
+export type {ASTNode} from './index.js'
+export default serializeDefault


### PR DESCRIPTION
**Types & APIs**
- Add `Optional<T>` generics
- Enhance error constructors: `node` param + `withAst()` method
- Export `check()` function
- Add `getDefinitions()` → introspect registered functions & variables
- Add `ResolvedEnvironmentOptions` type

**Module exports**
- Explicit exports (no wildcard)
- evaluator.d: explicit + default export
- serialize.d: explicit function declaration

**Registration overloads**
- `registerFunction/Variable/Constant/Type` accept signature + handler OR single declaration object
- New types: `RegisterTypeDefinition`, `RegisterTypeDeclaration`, `VariableDeclaration`
- Full definition export: `DefinitionFunction`, `DefinitionVariable`, `DefinitionsResult`

**Type system**
- `TypeDeclaration`: add `dyn|optional|param` kinds, transformation methods (`unwrapped`, `wrapped`, `unify`, `templated`)
- Properties now properly typed: `objectTypes`, `variables` (use `RegisteredType`, `VariableDeclaration`)

**Duration/UnsignedInt**
- `Duration`: add `fromMilliseconds()`, `valueOf()→number`, arithmetic ops, timestamp ops, time getters
- `UnsignedInt`: add `verify()` method