### PR TITLE
fix!: rename Evaluator.eval() to run() so cel-js can be bundled under SES

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ env.registerFunction('macro(ast): dyn', ({ast, args}) => {
     },
     // Mandatory: called when the expression is evaluated
     evaluate(evaluator, macro, ctx) {
-      return evaluator.eval(macro.firstArgument, ctx)
+      return evaluator.run(macro.firstArgument, ctx)
     }
   }
 })

--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -154,7 +154,7 @@ class Evaluator extends Base {
 
   tryEval(ast, ctx) {
     try {
-      const res = this.eval(ast, ctx)
+      const res = this.run(ast, ctx)
       if (res instanceof Promise) return res.catch((err) => err)
       return res
     } catch (err) {
@@ -162,7 +162,7 @@ class Evaluator extends Base {
     }
   }
 
-  eval(ast, ctx) {
+  run(ast, ctx) {
     return ast.evaluate(this, ast, ctx)
   }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -497,7 +497,7 @@ export class Environment {
    *     return checker.check(macro.firstArgument, ctx)
    *   },
    *   evaluate(evaluator, macro, ctx) {
-   *     return evaluator.eval(macro.firstArgument, ctx)
+   *     return evaluator.run(macro.firstArgument, ctx)
    *   }
    * }))
    * ```

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -87,7 +87,7 @@ function createHasExpander() {
   function evaluate(ev, macro, ctx) {
     const nodes = macro.macroHasProps
     let i = nodes.length
-    let obj = ev.eval(nodes[--i], ctx)
+    let obj = ev.run(nodes[--i], ctx)
     let inOptionalContext
     while (i--) {
       const node = nodes[i]
@@ -201,19 +201,19 @@ export function registerMacros(registry) {
   }
 
   function bindOptionalEvaluate(ev, exp, bindCtx, ctx, boundValue) {
-    const res = ev.eval(exp, (ctx = bindCtx.reuse(ctx).setIterValue(boundValue, ev)))
+    const res = ev.run(exp, (ctx = bindCtx.reuse(ctx).setIterValue(boundValue, ev)))
     if (res instanceof Promise && ctx === bindCtx) ctx.async = true
     return res
   }
 
   function bindEvaluate(ev, {val, exp, bindCtx}, ctx) {
-    const v = ev.eval(val, ctx)
+    const v = ev.run(val, ctx)
     if (v instanceof Promise) return v.then((_v) => bindOptionalEvaluate(ev, exp, bindCtx, ctx, _v))
     return bindOptionalEvaluate(ev, exp, bindCtx, ctx, v)
   }
 
   function bindEvaluateSync(ev, {val, exp, bindCtx}, ctx) {
-    return ev.eval(exp, bindCtx.reuse(ctx).setIterValue(ev.eval(val, ctx), ev))
+    return ev.run(exp, bindCtx.reuse(ctx).setIterValue(ev.run(val, ctx), ev))
   }
 
   functionOverload('CelNamespace.bind(ast, dyn, ast): dyn', ({ast, args}) => {

--- a/lib/operators.js
+++ b/lib/operators.js
@@ -147,8 +147,8 @@ function ternaryConditionError(ev, value, node) {
 }
 
 function handleTernary(c, ev, ast, ctx) {
-  if (c === true) return ev.eval(ast.left, ctx)
-  if (c === false) return ev.eval(ast.right, ctx)
+  if (c === true) return ev.run(ast.left, ctx)
+  if (c === false) return ev.run(ast.right, ctx)
   throw ternaryConditionError(ev, c, ast.condition)
 }
 
@@ -236,7 +236,7 @@ function handleUnary(left, ast, ev) {
 }
 
 function evaluateUnary(ev, ast, ctx) {
-  return ast.handle(ev.eval(ast.args, ctx), ast, ev)
+  return ast.handle(ev.run(ast.args, ctx), ast, ev)
 }
 
 function checkBinary(chk, ast, ctx) {
@@ -264,11 +264,11 @@ function checkBinary(chk, ast, ctx) {
 }
 
 function evaluateBinary(ev, ast, ctx) {
-  return ast.handle(ev.eval(ast.left, ctx), ev.eval(ast.right, ctx), ast, ev)
+  return ast.handle(ev.run(ast.left, ctx), ev.run(ast.right, ctx), ast, ev)
 }
 
 function evaluateBinaryFirst(ev, ast, ctx) {
-  return ast.handle(ev.eval(ast.left, ctx), ast.right, ast, ev)
+  return ast.handle(ev.run(ast.left, ctx), ast.right, ast, ev)
 }
 
 function handleBinary(left, right, ast, ev) {
@@ -338,7 +338,7 @@ function resolveAstArray(ev, astArray, ctx, i = astArray.length) {
 
   let async
   const results = new Array(i)
-  while (i--) if ((results[i] = ev.eval(astArray[i], ctx)) instanceof Promise) async ??= true
+  while (i--) if ((results[i] = ev.run(astArray[i], ctx)) instanceof Promise) async ??= true
   return async ? Promise.all(results) : results
 }
 
@@ -381,7 +381,7 @@ function toIterable(ev, args, coll) {
 
 function runQualifier(items, args, ev, ctx) {
   if (!isArray(items)) items = toIterable(ev, args, items)
-  const accu = ev.eval(args.init, (ctx = args.iterCtx.reuse(ctx)))
+  const accu = ev.run(args.init, (ctx = args.iterCtx.reuse(ctx)))
   ctx.accuValue = accu
   if (ctx === args.iterCtx) return iterateQuantifier(ev, ctx, args, items, accu, 0)
   return continueQuantifier(ev, ctx, args, items, accu, 0)
@@ -389,7 +389,7 @@ function runQualifier(items, args, ev, ctx) {
 
 function runComprehension(items, args, ev, ctx) {
   if (!isArray(items)) items = toIterable(ev, args, items)
-  const accu = ev.eval(args.init, (ctx = args.iterCtx.reuse(ctx)))
+  const accu = ev.run(args.init, (ctx = args.iterCtx.reuse(ctx)))
   ctx.accuValue = accu
   if (ctx === args.iterCtx) return iterateLoop(ev, ctx, args, items, accu, 0)
   return continueLoop(ev, ctx, args, items, accu, 0)
@@ -401,7 +401,7 @@ function iterateLoop(ev, ctx, args, items, accu, i) {
   const len = items.length
   while (i < len) {
     if (condition && !condition(accu)) break
-    accu = ev.eval(step, ctx.setIterValue(items[i++], ev))
+    accu = ev.run(step, ctx.setIterValue(items[i++], ev))
     if (accu instanceof Promise) return continueLoop(ev, ctx, args, items, accu, i)
   }
   return args.result(accu)
@@ -415,7 +415,7 @@ async function continueLoop(ev, ctx, args, items, accu, i) {
   accu = await accu
   while (i < len) {
     if (condition && !condition(accu)) return args.result(accu)
-    accu = ev.eval(step, ctx.setIterValue(items[i++], ev))
+    accu = ev.run(step, ctx.setIterValue(items[i++], ev))
     if (accu instanceof Promise) accu = await accu
   }
   return args.result(accu)
@@ -648,8 +648,8 @@ export const OPERATORS = {
       let async
       for (let i = 0; i < len; i++) {
         const e = astEntries[i]
-        const k = ev.eval(e[0], ctx)
-        const v = ev.eval(e[1], ctx)
+        const k = ev.run(e[0], ctx)
+        const v = ev.run(e[1], ctx)
         if (k instanceof Promise || v instanceof Promise) {
           results[i] = Promise.all([k, v])
           async ??= true
@@ -675,7 +675,7 @@ export const OPERATORS = {
       return stepType
     },
     evaluate(ev, ast, ctx) {
-      return ast.handle(ev.eval(ast.args.iterable, ctx), ast.args, ev, ctx)
+      return ast.handle(ev.run(ast.args.iterable, ctx), ast.args, ev, ctx)
     }
   },
   accuValue: {
@@ -703,11 +703,11 @@ export const OPERATORS = {
       return chk.registry.getListType(itemType)
     },
     evaluateSync(ev, ast, ctx) {
-      return (ctx.accuValue.push(ev.eval(ast.args, ctx)), ctx.accuValue)
+      return (ctx.accuValue.push(ev.run(ast.args, ctx)), ctx.accuValue)
     },
     evaluate(ev, ast, ctx) {
       const arr = ctx.accuValue
-      const el = ev.eval(ast.args, ctx)
+      const el = ev.run(ast.args, ctx)
       if (el instanceof Promise) return el.then((_e) => arr.push(_e) && arr)
       arr.push(el)
       return arr
@@ -744,7 +744,7 @@ export const OPERATORS = {
       )
     },
     evaluate(ev, ast, ctx) {
-      return ast.handle(ev.eval(ast.condition, ctx), ev, ast, ctx)
+      return ast.handle(ev.run(ast.condition, ctx), ev, ast, ctx)
     }
   },
   '||': {
@@ -753,15 +753,15 @@ export const OPERATORS = {
       const l = ev.tryEval(ast.left, ctx)
       if (l === true) return true
       if (l === false) {
-        const right = ev.eval(ast.right, ctx)
+        const right = ev.run(ast.right, ctx)
         if (typeof right === 'boolean') return right
         return _logicalOp(true, ev, ast, l, right)
       }
       if (l instanceof Promise)
         return l.then((_l) =>
-          _l === true ? _l : _logicalOp(true, ev, ast, _l, ev.eval(ast.right, ctx))
+          _l === true ? _l : _logicalOp(true, ev, ast, _l, ev.run(ast.right, ctx))
         )
-      return _logicalOp(true, ev, ast, l, ev.eval(ast.right, ctx))
+      return _logicalOp(true, ev, ast, l, ev.run(ast.right, ctx))
     }
   },
   '&&': {
@@ -770,15 +770,15 @@ export const OPERATORS = {
       const l = ev.tryEval(ast.left, ctx)
       if (l === false) return false
       if (l === true) {
-        const right = ev.eval(ast.right, ctx)
+        const right = ev.run(ast.right, ctx)
         if (typeof right === 'boolean') return right
         return _logicalOp(false, ev, ast, l, right)
       }
       if (l instanceof Promise)
         return l.then((_l) =>
-          _l === false ? _l : _logicalOp(false, ev, ast, _l, ev.eval(ast.right, ctx))
+          _l === false ? _l : _logicalOp(false, ev, ast, _l, ev.run(ast.right, ctx))
         )
-      return _logicalOp(false, ev, ast, l, ev.eval(ast.right, ctx))
+      return _logicalOp(false, ev, ast, l, ev.run(ast.right, ctx))
     }
   },
   '!_': {alias: 'unaryNot', check: checkUnary, evaluate: evaluateUnary},

--- a/lib/optional.js
+++ b/lib/optional.js
@@ -79,7 +79,7 @@ export function register(registry) {
   }
 
   function evaluateOptional(ev, macro, ctx) {
-    const v = ev.eval(macro.receiver, ctx)
+    const v = ev.run(macro.receiver, ctx)
     if (v instanceof Promise) return v.then((_v) => handleOptionalResolved(_v, ev, macro, ctx))
     return handleOptionalResolved(v, ev, macro, ctx)
   }
@@ -134,7 +134,7 @@ export function register(registry) {
       onHasValue: (optional) => optional,
       onEmpty(ev, macro, ctx) {
         const ast = macro.arg
-        const v = ev.eval(ast, ctx)
+        const v = ev.run(ast, ctx)
         if (v instanceof Promise) return v.then((_v) => ensureOptional(_v, ast, invalidOrArg))
         return ensureOptional(v, ast, invalidOrArg)
       }
@@ -147,7 +147,7 @@ export function register(registry) {
       functionDesc: 'optional.orValue(value)',
       onHasValue: (optionalValue) => optionalValue.value(),
       onEmpty(ev, macro, ctx) {
-        return ev.eval(macro.arg, ctx)
+        return ev.run(macro.arg, ctx)
       },
       evaluate: evaluateOptional,
       typeCheck(check, macro, ctx) {

--- a/test/overlapping-overloads.test.js
+++ b/test/overlapping-overloads.test.js
@@ -122,7 +122,7 @@ describe('Overlapping function overloads', () => {
             return checker.check(macro.firstArgument, ctx)
           },
           evaluate(evaluator, macro, ctx) {
-            return evaluator.eval(macro.firstArgument, ctx)
+            return evaluator.run(macro.firstArgument, ctx)
           }
         }
       })
@@ -164,8 +164,8 @@ describe('Overlapping function overloads', () => {
 
     test('multiple ast arguments allowed', () => {
       const env = new Environment()
-      env.registerFunction('macro(ast): dyn', (ast) => this.eval(ast))
-      env.registerFunction('macro(ast, ast): dyn', (a, b) => this.eval(a) + this.eval(b))
+      env.registerFunction('macro(ast): dyn', (ast) => this.run(ast))
+      env.registerFunction('macro(ast, ast): dyn', (a, b) => this.run(a) + this.run(b))
     })
   })
 


### PR DESCRIPTION
Fixes #98.

The Evaluator's recursive node-evaluation method is named `eval`. When cel-js gets bundled and minified — for example into a MetaMask Snap — that method ends up as a bare `eval(...)` in the output, and SES's static "direct eval" check can't tell it apart from a real `eval()`, so it rejects the whole bundle. That makes cel-js, and anything that depends on it, impossible to use inside a snap.

This renames the method to `run`: the definition on `Evaluator`, the internal call sites across operators/macros/optional, and the `evaluator.eval(...)` examples in the README and index.d.ts. I went with `run` rather than `evaluate` because `evaluate` is already the public string-expression entry point (`Environment.evaluate` and the top-level `evaluate()`), so reusing it would be confusing.

It's a breaking change for anyone calling `evaluator.eval(node, ctx)` directly from a custom function or macro — they'd need to move to `evaluator.run(node, ctx)`. Happy to use a different name if you'd prefer. Worth noting that a deprecated alias wouldn't help: keeping an `eval` method around leaves the token in the bundle, so SES would still reject it. A plain rename is the only thing that unblocks bundling.

All 1053 tests pass unchanged.
